### PR TITLE
Assert::error() prints all unexpected errors.

### DIFF
--- a/tests/Assert.error.phpt
+++ b/tests/Assert.error.phpt
@@ -29,3 +29,10 @@ Assert::exception(function(){
 		$a++;
 	}, E_NOTICE, 'Abc');
 }, 'Tester\AssertException', 'Failed asserting that "Undefined variable: a" matches expected "Abc"');
+
+Assert::exception(function(){
+	Assert::error(function(){
+		$a++;
+		$b++;
+	}, E_NOTICE, 'Undefined variable: a');
+}, 'Tester\AssertException', 'Unexpected error E_NOTICE (Undefined variable: b) in file %a%(%d%)');


### PR DESCRIPTION
Useful when using the Assert::error() and callback generates for example E_NOTICE before expected error:

``` php
Assert::error(function() {
    $a++;
    trigger_error('Bad file content', E_USER_WARNING);
}, E_USER_WARNING, 'Bad file content');
```

Current behaviour is:

```
-- FAILED: Test | test.phpt
   Unexpected error Bad file content in file.php:123
```
