### PR TITLE
TestCase: support for throws annotation [Closes #16]

### DIFF
--- a/tests/TestCase.annotationThrows.phpt
+++ b/tests/TestCase.annotationThrows.phpt
@@ -51,16 +51,16 @@ class MyTest extends Tester\TestCase
 	{
 		throw new Exception;
 	}
-	
+
 	public function dataProvider()
 	{
 		return array(array(1));
 	}
-	
+
 	/**
 	 * @dataprovider dataProvider
-	 * @throws Exception	 
-	 */	 	
+	 * @throws Exception
+	 */
 	public function testThrowsWithDataprovider($x)
 	{
 	}
@@ -73,7 +73,7 @@ $test->run('testThrowsMessage');
 
 Assert::exception(function() use ($test) {
 	$test->run('testThrowsButDont');
-}, 'Tester\AssertException', 'Expected exception Exception in MyTest::testThrowsButDont() method');
+}, 'Tester\AssertException', 'Expected exception Exception');
 
 Assert::exception(function() use ($test) {
 	$test->run('testFailAssertPass');
@@ -81,11 +81,11 @@ Assert::exception(function() use ($test) {
 
 Assert::exception(function() use ($test) {
 	$test->run('testThrowsBadClass');
-}, 'Tester\AssertException', 'Failed asserting that Exception is an instance of class MyException in MyTest::testThrowsBadClass() method');
+}, 'Tester\AssertException', 'Failed asserting that Exception is an instance of class MyException');
 
 Assert::exception(function() use ($test) {
 	$test->run('testThrowsBadMessage');
-}, 'Tester\AssertException', 'Failed asserting that "Bad message" matches expected "With message" in MyTest::testThrowsBadMessage() method');
+}, 'Tester\AssertException', 'Failed asserting that "Bad message" matches expected "With message"');
 
 Assert::exception(function() use ($test) {
 	$test->run('testWithoutThrows');
@@ -93,10 +93,4 @@ Assert::exception(function() use ($test) {
 
 Assert::exception(function() use ($test) {
 	$test->run('testThrowsWithDataprovider');
-}, 'Exception', 'Expected exception Exception in MyTest::testThrowsWithDataprovider() method (dataprovider #0)');
-
-
-
-Assert::exception(function() use ($test) {
-	$test->run('testUndefinedMethod');
-}, 'ReflectionException', 'Method testUndefinedMethod does not exist');
+}, 'Exception', 'Expected exception Exception');

--- a/tests/TestCase.annotationThrows.syntax.phpt
+++ b/tests/TestCase.annotationThrows.syntax.phpt
@@ -4,7 +4,6 @@ use Tester\Assert;
 
 require __DIR__ . '/bootstrap.php';
 
-
 class MyTest extends Tester\TestCase
 {
 	/**
@@ -28,8 +27,19 @@ $test = new MyTest;
 
 Assert::exception(function() use ($test) {
 	$test->run('testThrowsNoClass');
-}, 'Tester\TestCaseException', 'Missing class name in @throws annotation for MyTest::testThrowsNoClass() method.');
+}, 'Tester\TestCaseException', 'Missing class name in @throws annotation.');
 
-Assert::exception(function() use ($test) {
+$e = Assert::exception(function() use ($test) {
 	$test->run('testThrowsMultiple');
-}, 'Tester\TestCaseException', 'Cannot specify @throws annotation for MyTest::testThrowsMultiple() method more then once.');
+}, 'Tester\TestCaseException', 'Cannot specify @throws annotation more then once.');
+
+$rm = new ReflectionMethod($test, 'testThrowsMultiple');
+$trace = $e->getTrace();
+Assert::same(array(
+	'file' => __FILE__,
+	'line' => $rm->getStartLine(),
+	'function' => 'testThrowsMultiple',
+	'class' => 'MyTest',
+	'type' => '->',
+	'args' => array(),
+), end($trace));

--- a/tests/TestCase.missingDataProvider.phpt
+++ b/tests/TestCase.missingDataProvider.phpt
@@ -18,4 +18,4 @@ class MissingDataProviderTest extends Tester\TestCase
 Assert::exception(function(){
 	$test = new MissingDataProviderTest;
 	$test->run();
-}, 'Tester\TestCaseException', "Method testDataProvider() has arguments, but @dataProvider is missing.");
+}, 'Tester\TestCaseException', "Method has arguments, but @dataProvider is missing.");


### PR DESCRIPTION
An attempt to implement support for @throws annotation for TestCase test methods.

Problem is with backtrace when tested method does not throw an expected exception (method call is missing in backtrace). I substituted it by suffix to fail message.

Would not be better to add something like `AssertException::addToBacktrace($methodReflection)`?
