### PR TITLE
TestCase should have setExpectedException

### DIFF
--- a/Tester/Framework/TestCase.php
+++ b/Tester/Framework/TestCase.php
@@ -20,6 +20,13 @@ namespace Tester;
  */
 class TestCase
 {
+	/** @var string */
+	protected $expectedException;
+
+	/** @var string */
+	protected $expectedExceptionMessage;
+
+
 
 	/**
 	 * Runs the test case.
@@ -59,18 +66,44 @@ class TestCase
 
 
 	/**
+	 * Sets expected exception.
+	 * @param  string exception class
+	 * @param  string exception message
+	 */
+	public function setExpectedException($class, $message = '')
+	{
+		$this->expectedException = $class;
+		$this->expectedExceptionMessage = $message;
+	}
+
+
+
+	/**
 	 * Runs the single test.
+	 * @param  string method name
+	 * @param  array arguments
 	 * @return void
 	 */
 	public function runTest($name, array $args = array())
 	{
+		$this->expectedException = NULL;
+		$this->expectedExceptionMessage = NULL;
+		$e = NULL;
+
 		$this->setUp();
 		try {
 			call_user_func_array(array($this, $name), $args);
 		} catch (\Exception $e) {
 		}
 		$this->tearDown();
-		if (isset($e)) {
+
+		if ($this->expectedException) {
+			Assert::exception(function() use($e) {
+				if ($e instanceof \Exception) {
+					throw $e;
+				}
+			}, $this->expectedException, $this->expectedExceptionMessage);
+		} elseif ($e) {
 			throw $e;
 		}
 	}

--- a/tests/TestCase.expectedException.phpt
+++ b/tests/TestCase.expectedException.phpt
@@ -1,0 +1,76 @@
+<?php
+
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+
+class CaughtCase extends Tester\TestCase
+{
+	public function testThrown()
+	{
+		$this->setExpectedException('Exception');
+		throw new \Exception();
+	}
+}
+
+$test = new CaughtCase;
+$test->run();
+
+
+
+class UncaughtCase extends Tester\TestCase
+{
+	public function testUncaught()
+	{
+		throw new \Exception();
+	}
+}
+
+Assert::exception(function(){
+	$test = new UncaughtCase;
+	$test->run();
+}, 'Exception', '');
+
+
+
+class WrongCase extends Tester\TestCase
+{
+	public function testThrown()
+	{
+		$this->setExpectedException('RuntimeException');
+		throw new \Exception;
+	}
+}
+
+Assert::exception(function(){
+	$test = new WrongCase;
+	$test->run();
+}, 'Tester\AssertException', 'Failed asserting that Exception is an instance of class RuntimeException');
+
+
+
+class UnthrownCase extends Tester\TestCase
+{
+	public function testUnthrown()
+	{
+		$this->setExpectedException('Exception');
+	}
+}
+
+Assert::exception(function(){
+	$test = new UnthrownCase;
+	$test->run();
+}, 'Tester\AssertException', 'Expected exception Exception');
+
+
+
+class NothingCase extends Tester\TestCase
+{
+	public function testNothing()
+	{
+	}
+}
+
+$test = new NothingCase;
+$test->run();


### PR DESCRIPTION
Testing exceptions using Assert::exception() is pretty uncomfortable. Calling one method is much more easier and shorter than creating callback function.
