### PR TITLE
Changed terminal colors detection

### DIFF
--- a/Tester/Framework/Environment.php
+++ b/Tester/Framework/Environment.php
@@ -70,8 +70,22 @@ class Environment
 	{
 		$colors = getenv('NETTE_TESTER_COLORS');
 		return $colors === FALSE
-			? (defined('STDOUT') && function_exists('posix_isatty') && posix_isatty(STDOUT))
+			? static::detectColors()
 			: (bool) $colors;
+	}
+
+
+	/**
+	 * @return bool
+	 * @internal
+	 */
+	public static function detectColors()
+	{
+		return PHP_SAPI === 'cli' && (
+			getenv('ConEmuANSI') === 'ON'
+			|| getenv('ANSICON') !== FALSE
+			|| (defined('STDOUT') && function_exists('posix_isatty') && posix_isatty(STDOUT))
+		);
 	}
 
 

--- a/Tester/tester.php
+++ b/Tester/tester.php
@@ -64,7 +64,7 @@ if ($cmd->isEmpty()) {
 
 if (isset($options['--colors'])) {
 	putenv('NETTE_TESTER_COLORS=' . (int) $options['--colors']);
-} elseif (getenv('NETTE_TESTER_COLORS') === FALSE && (getenv('ConEmuANSI') === 'ON' || getenv('ANSICON') !== FALSE)) {
+} elseif (getenv('NETTE_TESTER_COLORS') === FALSE && Tester\Environment::detectColors()) {
 	putenv('NETTE_TESTER_COLORS=1');
 }
 


### PR DESCRIPTION
Without this, test runned manually by `php test.phpt` is not colored on Windows.

If you do not want to merge this, please, remove [this](https://github.com/nette/tester/blob/master/Tester/tester.php#L51) line at least.

Sorry for poking :)
