### PR TITLE
Fixed error with indexes in arrays created by type cast from object

### DIFF
--- a/Tester/Framework/Assert.php
+++ b/Tester/Framework/Assert.php
@@ -454,6 +454,10 @@ class Assert
 			if ($arr1 !== $arr2) {
 				return FALSE;
 			}
+			ksort($expected);
+			$expected = array_values($expected);
+			ksort($actual);
+			$actual = array_values($actual);
 
 			foreach ($expected as $key => $value) {
 				if (!self::isEqual($value, $actual[$key], $level + 1)) {

--- a/tests/Assert.equal.phpt
+++ b/tests/Assert.equal.phpt
@@ -5,6 +5,23 @@ use Tester\Assert;
 require __DIR__ . '/bootstrap.php';
 
 
+$collectionItemOne = new stdClass;
+$collectionItemOne->name = "item one";
+
+$collectionItemTwo = new stdClass;
+$collectionItemTwo->name = "item two";
+
+$zero = 0;
+$one = 1;
+
+$collectionOne = new stdClass();
+$collectionOne->{$zero} = $collectionItemOne;
+$collectionOne->{$one} = $collectionItemTwo;
+
+$collectionTwo = new stdClass();
+$collectionTwo->{$one} = $collectionItemTwo;
+$collectionTwo->{$zero} = $collectionItemOne;
+
 $equals = array(
 	array(1, 1),
 	array('1', '1'),
@@ -13,6 +30,7 @@ $equals = array(
 	array(new stdClass, new stdClass),
 	array(array(new stdClass), array(new stdClass)),
 	array(1/3, 1 - 2/3),
+	array($collectionOne, $collectionTwo),
 );
 
 $notEquals = array(


### PR DESCRIPTION
When I have tried to use method `Assert::equal` with `Nette\ArrayHash` instances as arguments then I got following answer.

```
ErrorException: Undefined offset: 0
```

This pull request solves problem with object type casting to array.

Updated test included.
