### PR TITLE
Added coverage-report to bin

### DIFF
--- a/Tester/coverage-report
+++ b/Tester/coverage-report
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__ . '/coverage-report.php';

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,5 @@
 	"autoload": {
 		"classmap": ["Tester/"]
 	},
-	"bin": ["Tester/tester"]
+	"bin": ["Tester/tester", "Tester/coverage-report"]
 }


### PR DESCRIPTION
If we have tester in binaries, why not coverage-report, which is executable file too.
