### PR TITLE
Exception form test should have higher priority than exception from tearDown.

### DIFF
--- a/Tester/Framework/TestCase.php
+++ b/Tester/Framework/TestCase.php
@@ -91,9 +91,15 @@ class TestCase
 			call_user_func_array(array($this, $name), $args);
 		} catch (\Exception $e) {
 		}
-		$this->tearDown();
+		try {
+		  $this->tearDown();
+		} catch (\Exception $tearDownEx) {
+		}
 		if (isset($e)) {
 			throw $e;
+		}
+		if (isset($tearDownEx)) {
+			throw $tearDownEx;
 		}
 	}
 


### PR DESCRIPTION
When exception from test is thrown and then exception form tearDown is thrown too (probably as result of first exception) then exception from test should be thrown from runTest method rather than exception from tearDown. It is more likely that exception from test it one which is interesting for us.
