### PR TITLE
debian - can use php-unix.ini

### DIFF
--- a/Tester/tester.php
+++ b/Tester/tester.php
@@ -70,8 +70,9 @@ if ($cmd->isEmpty() || $options['--help']) {
 	exit;
 }
 
-$phpArgs = $options['-c'] ? '-c ' . escapeshellarg($options['-c']) : '-n';
-foreach ($options['-d'] as $item) {
+$phpArgs = '-n'; // strip all default ini files
+$phpArgs .= $options['-c'] ? ' -c ' . escapeshellarg($options['-c']) : ''; // use custom ini file
+foreach ($options['-d'] as $item) { // set ini value
 	$phpArgs .= ' -d ' . escapeshellarg($item);
 }
 


### PR DESCRIPTION
On Windows default php.ini is replaced by one passed by -c parametr, but on Debian (don't know how about another linux distributions, but it doesn't matter) is new php.ini added to all settings (default php.ini, modules .ini - https://wiki.debian.org/PHP/). This file is parsed first, so every setting you would change is replaced by default php.ini or modules settings. It makes sense to clear all configuration files every time (php -n).
