### PR TITLE
Assert::equal() - Fixed false fail when comparing arrays with mixed type...

### DIFF
--- a/Tester/Framework/Assert.php
+++ b/Tester/Framework/Assert.php
@@ -441,8 +441,8 @@ class Assert
 		}
 
 		if (is_array($expected) && is_array($actual)) {
-			ksort($expected);
-			ksort($actual);
+			ksort($expected, SORT_STRING);
+			ksort($actual, SORT_STRING);
 			if (array_keys($expected) !== array_keys($actual)) {
 				return FALSE;
 			}

--- a/tests/Assert.equal.phpt
+++ b/tests/Assert.equal.phpt
@@ -23,6 +23,7 @@ $equals = array(
 	array(array(new stdClass), array(new stdClass)),
 	array(1/3, 1 - 2/3),
 	array($obj1, $obj2),
+	array(array(0 => 'a', 'str' => 'b'), array('str' => 'b', 0 => 'a')),
 );
 
 $notEquals = array(


### PR DESCRIPTION
...s in keys
