### PR TITLE
 Assert: floats comparison checks relative error

### DIFF
--- a/Tester/Framework/Assert.php
+++ b/Tester/Framework/Assert.php
@@ -438,7 +438,7 @@ class Assert
 		}
 
 		if (is_float($expected) && is_float($actual)) {
-			return abs($expected - $actual) < self::EPSILON;
+			return ($expected === $actual) || (abs($expected - $actual) / max(abs($expected), abs($actual)) < self::EPSILON);
 		}
 
 		if (is_object($expected) && is_object($actual) && get_class($expected) === get_class($actual)) {

--- a/tests/Assert.equal.phpt
+++ b/tests/Assert.equal.phpt
@@ -25,6 +25,8 @@ $equals = array(
 	array(new stdClass, new stdClass),
 	array(array(new stdClass), array(new stdClass)),
 	array(1/3, 1 - 2/3),
+	array(1/3*1e9, (1 - 2/3)*1e9),
+	array(0.0, 0.0),
 	array($obj1, $obj2),
 	array(array(0 => 'a', 'str' => 'b'), array('str' => 'b', 0 => 'a')),
 	array($deep1, $deep2),


### PR DESCRIPTION
Comparison of large floats does not work because current implementation uses checks absolute error.

See http://stackoverflow.com/questions/3148937/compare-floats-in-php for information about how to properly compare floats.
