### PR TITLE
Assert: check both relative and absolute error when comparing floats

### DIFF
--- a/Tester/Framework/Assert.php
+++ b/Tester/Framework/Assert.php
@@ -437,7 +437,7 @@ class Assert
 			throw new \Exception('Nesting level too deep or recursive dependency.');
 		}
 
-		if (is_float($expected) && is_float($actual)) {
+		if (is_float($expected) && is_float($actual) && is_finite($expected) && is_finite($actual)) {
 			$diff = abs($expected - $actual);
 			return ($diff < self::EPSILON) || ($diff / max(abs($expected), abs($actual)) < self::EPSILON);
 		}

--- a/tests/Assert.equal.phpt
+++ b/tests/Assert.equal.phpt
@@ -32,6 +32,7 @@ $equals = array(
 	array($float1 - $float2, 0.0),
 	array($float1 - $float2, $float2 - $float1),
 	array(0.0, 0.0),
+	array(INF, INF),
 	array($obj1, $obj2),
 	array(array(0 => 'a', 'str' => 'b'), array('str' => 'b', 0 => 'a')),
 	array($deep1, $deep2),
@@ -39,6 +40,8 @@ $equals = array(
 
 $notEquals = array(
 	array(1, 1.0),
+	array(INF, -INF),
+	array(NAN, NAN),
 	array(array('a', 'b'), array('b', 'a')),
 );
 


### PR DESCRIPTION
As it turns out you actually need to check both relative and absolute error :smile_cat: 
