### PR TITLE
Fix call php in some version of php

### DIFF
--- a/Tester/tester.php
+++ b/Tester/tester.php
@@ -66,7 +66,7 @@ if ($cmd->isEmpty() || $options['--help']) {
 	exit;
 }
 
-$phpArgs = $options['-c'] ? '-n -c ' . escapeshellarg($options['-c']) : '-n';
+$phpArgs = $options['-c'] ? '-c ' . escapeshellarg($options['-c']) : '-n';
 foreach ($options['-d'] as $item) {
 	$phpArgs .= ' -d ' . escapeshellarg($item);
 }


### PR DESCRIPTION
Remove php argument -n if -c is present.

In some versions of php (for example 5.5.7) has -n higher priority. See http://forum.nette.org/en/1305-nette-tester-php-modules-are-not-loaded
