### PR TITLE
Backwards compatibility for listing methods + bugfix

### DIFF
--- a/Tester/Framework/TestCase.php
+++ b/Tester/Framework/TestCase.php
@@ -28,7 +28,7 @@ class TestCase
 	{
 		if (($method === NULL || $method === self::LIST_METHODS) && isset($_SERVER['argv'][1])) {
 			if ($_SERVER['argv'][1] === self::LIST_METHODS) {
-				echo json_encode(preg_grep(self::METHOD_PATTERN, get_class_methods($this)));
+				echo json_encode(array_values(preg_grep(self::METHOD_PATTERN, get_class_methods($this))));
 				return;
 			}
 			$method = $_SERVER['argv'][1];


### PR DESCRIPTION
Because every single user of this package was using it like this

``` php
$testCase->run(isset($_SERVER['argv'][1]) ? $_SERVER['argv'][1] : NULL);
```

[this condition](https://github.com/nette/tester/blob/8fcaa8ce76acf1b12375ad711a133435004cf5a0/Tester/Framework/TestCase.php#L29) means **everyone's** test suites are now broken.

https://travis-ci.org/Kdyby/Doctrine/jobs/16905118

![5a0](https://f.cloud.github.com/assets/158625/1906967/4d702bec-7cbe-11e3-9a0c-bc2123947c99.jpg)

---

When the first method in the testcase doesn't match the regexp, than the output json looks like this

``` js
{"1":"testMatchNumber","3":"testMatchStreet"}
```

Which obviousely breaks this search https://github.com/nette/tester/blob/8fcaa8ce76acf1b12375ad711a133435004cf5a0/Tester/Runner/TestHandler.php#L158
