### PR TITLE
ASCII art and help screen tweaks

### DIFF
--- a/Tester/tester.php
+++ b/Tester/tester.php
@@ -36,17 +36,17 @@ $cmd = new Cmd("Usage:
     tester.php [options] [<test file> | <directory>]...
 
 Options:
-    -p <path>            Specify PHP executable to run (default: php-cgi).
-    -c <path>            Look for php.ini file (or look in directory) <path>.
-    -log <path>          Write log to file <path>.
-    -d <key=value>...    Define INI entry 'key' with value 'val'.
-    -s                   Show information about skipped tests.
-    --tap                Generate Test Anything Protocol.
-    -j <num>             Run <num> jobs in parallel.
-    -w | --watch <path>  Watch directory.
-    --setup <path>       Script for runner setup.
-    --colors [1|0]       Enable or disable colors.
-    -h | --help          This help.
+    -p <path>            specify PHP executable to run (default: php-cgi)
+    -c <path>            look for php.ini file (or look in directory) <path>
+    -log <path>          write log to file <path>
+    -d <key=value>...    define INI entry 'key' with value 'val'
+    -s                   show information about skipped tests
+    --tap                generate Test Anything Protocol
+    -j <num>             run <num> jobs in parallel
+    -w | --watch <path>  watch directory
+    --setup <path>       script for runner setup
+    --colors [1|0]       enable or disable colors
+    -h | --help          this help
 
 ", array(
 	'-c' => array(Cmd::REALPATH => TRUE),


### PR DESCRIPTION
It is very personal opinion, but I think that help screen is better readable in this format. The big letters pull eyes to much (looks like some shortcuts) and whole sentence just don't fit to me. This is common Linux format and it is opposite to most Windows helps.

And to ASCII art... When someone will see title "Nette TESTER", it is easier to google it than Tester alone.
