### PR TITLE
Dumper: format DateTime to formatted string instead of object hash

### DIFF
--- a/Tester/Framework/Dumper.php
+++ b/Tester/Framework/Dumper.php
@@ -81,7 +81,7 @@ class Dumper
 			return 'Exception ' . get_class($var) . ': ' . ($var->getCode() ? '#' . $var->getCode() . ' ' : '') . $var->getMessage();
 
 		} elseif (is_object($var)) {
-			return get_class($var) . '(#' . substr(md5(spl_object_hash($var)), 0, 4) . ')';
+			return self::formatObjectToLine($var);
 
 		} elseif (is_resource($var)) {
 			return 'resource(' . get_resource_type($var) . ')';
@@ -89,6 +89,23 @@ class Dumper
 		} else {
 			return 'unknown type';
 		}
+	}
+
+
+
+	/**
+	 * Formats object to line.
+	 * @param  object  object to format
+	 * @return string
+	 */
+	private static function formatObjectToLine($object)
+	{
+		$formatted = '';
+		if ($object instanceof \DateTime || (PHP_VERSION_ID >= 50500 && $object instanceof \DateTimeInterface)) {
+			$formatted = "'" . $object->format(\DateTime::ISO8601) . "'";
+		}
+
+		return get_class($object) . '(' . $formatted . '#' . substr(md5(spl_object_hash($object)), 0, 4) . ')';
 	}
 
 

--- a/tests/Dumper.toLine.phpt
+++ b/tests/Dumper.toLine.phpt
@@ -26,6 +26,10 @@ Assert::match( "'multi\nline'", Dumper::toLine("multi\nline") );
 Assert::match( "'Iñtërnâtiônàlizætiøn'", Dumper::toLine("I\xc3\xb1t\xc3\xabrn\xc3\xa2ti\xc3\xb4n\xc3\xa0liz\xc3\xa6ti\xc3\xb8n") );
 Assert::match( "resource(stream)", Dumper::toLine(fopen(__FILE__, 'r')) );
 Assert::match( 'stdClass(#%a%)', Dumper::toLine((object) array(1, 2)) );
+Assert::match('DateTime(\'2014-02-13T12:34:56+0100\'#%a%)', Dumper::toLine(new DateTime("2014-02-13 12:34:56")));
+if (PHP_VERSION_ID >= 50500) {
+	Assert::match('DateTimeImmutable(\'2014-02-13T12:34:56+0100\'#%a%)', Dumper::toLine(new DateTimeImmutable("2014-02-13 12:34:56")));
+}
 
 Assert::match( "array()", Dumper::toLine(array()) );
 Assert::match( "array(1, 2, 3, 4, 'x')", Dumper::toLine(array(1, 2, 3, 4, 'x')) );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,7 @@ require __DIR__ . '/../Tester/bootstrap.php';
 if (extension_loaded('xdebug')) {
 	Tester\CodeCoverage\Collector::start(__DIR__ . '/coverage.dat');
 }
+date_default_timezone_set("Europe/Prague");
 
 
 function test(\Closure $function)


### PR DESCRIPTION
I think usage of `DateTime` is often so it is nice to see formatted value instead of object hash.
