### PR TITLE
Master is alias for 1.1-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
 	"autoload": {
 		"classmap": ["Tester/"]
 	},
-	"bin": ["Tester/tester", "Tester/coverage-report"]
+	"bin": ["Tester/tester", "Tester/coverage-report"],
+	"extra": {
+		"branch-alias": { "dev-master": "1.1-dev" }
+	}
 }


### PR DESCRIPTION
This allows to reference the minimum version 1.0 with dev stability `~1.0@dev`
