### PR TITLE
Multiline skip message

### DIFF
--- a/Tester/Framework/Environment.php
+++ b/Tester/Framework/Environment.php
@@ -88,7 +88,7 @@ class Environment
 	 */
 	public static function skip($message = '')
 	{
-		echo "\nSkipped:\n$message\n";
+    echo "\nSkipped:\n" . strtr($message, "\r\n", "  ") . "\n";
 		die(Runner\Job::CODE_SKIP);
 	}
 


### PR DESCRIPTION
If multi-line messagee is passed to Environment::skip() the it is transformed to single-line. Otherwise only last line of message would be visible in output.
