### PR TITLE
DataProvider can use default values of target method

### DIFF
--- a/Tester/Framework/TestCase.php
+++ b/Tester/Framework/TestCase.php
@@ -80,7 +80,7 @@ class TestCase
 			if (!is_array($res)) {
 				throw new TestCaseException("Data provider $provider() doesn't return array.");
 			}
-			$data = array_merge($data, $res);
+			$data = array_merge($data, $this->fillDefaultParameters($res, $method));
 		}
 		if (!$info['dataprovider']) {
 			if ($method->getNumberOfRequiredParameters()) {
@@ -143,6 +143,30 @@ class TestCase
 		} else {
 			return $this->$provider();
 		}
+	}
+
+
+	/**
+	 * Fills unknown parameters by default ones.
+	 * @return array
+	 */
+	protected function fillDefaultParameters($parameters, \ReflectionMethod $method)
+	{
+		if (!count(array_filter(array_keys($parameters), 'is_string'))) {
+			// not associative array of parameters
+			return $parameters;
+		}
+
+		$defaultParametrs = array();
+		foreach ($method->getParameters() as $parameter) {
+			$defaultParametrs[$parameter->getName()] = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : NULL;
+		}
+
+		array_walk($parameters, function(&$item) use ($defaultParametrs) {
+			$item = array_merge($defaultParametrs, $item);
+		});
+
+		return $parameters;
 	}
 
 

--- a/tests/TestCase.dataProvider.phpt
+++ b/tests/TestCase.dataProvider.phpt
@@ -34,7 +34,13 @@ class MyTest extends Tester\TestCase
 	}
 
 	/** @dataProvider fixtures/dataprovider.query.ini != foo */
-	public function testFileDataProvider($data)
+	public function testFileDataProvider($a = '1')
+	{
+		$this->order[] = array(__METHOD__, func_get_args());
+	}
+
+	/** @dataProvider fixtures/dataprovider.query.ini != foo */
+	public function testFileDataProviderDefaultValues($a = '1', $b = '3')
 	{
 		$this->order[] = array(__METHOD__, func_get_args());
 	}
@@ -72,7 +78,15 @@ $test = new MyTest;
 $test->run('testFileDataProvider');
 Assert::same(array(
 	array('MyTest::testFileDataProvider', array('1')),
-	array('MyTest::testFileDataProvider', array('2')),
+	array('MyTest::testFileDataProvider', array('1', '2')),
+), $test->order);
+
+
+$test = new MyTest;
+$test->run('testFileDataProviderDefaultValues');
+Assert::same(array(
+	array('MyTest::testFileDataProviderDefaultValues', array('1', '3')),
+	array('MyTest::testFileDataProviderDefaultValues', array('1', '2')),
 ), $test->order);
 
 


### PR DESCRIPTION
This pull request allows to use named parameters in dataProvider. You can now also use default values of method's parameters.

ApiTests.php:

``` php
    /**
     * Tests one API request
     * @dataProvider api-calls.ini
     */
    public function testRequest($url, $schema, $method = 'GET', $authenticated = FALSE, $headers = [])
    {
        // validates API response using schema
    }
```

api-calls.ini

``` ini
[search]
url = "/search/?q=hitchhiker%27s+guide+to+the+galaxy"
schema = search.json

[buy]
url = "/buy/42"
schema = buy.json
authenticated = TRUE
```
