### PR TITLE
[Experiment] FastCGI support

### DIFF
--- a/Tester/Runner/FastCGIPhpSocket.php
+++ b/Tester/Runner/FastCGIPhpSocket.php
@@ -1,0 +1,504 @@
+<?php
+
+/**
+ * This file is part of the Nette Tester.
+ * Copyright (c) 2009 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Tester\Runner;
+
+use Tester\Environment;
+
+
+/**
+ * FastCGI PHP socket interpreter.
+ *
+ * @author     Miloslav Hůla
+ */
+class FastCGIPhpSocket implements IPhpInterpreter
+{
+	/** Version of FastCGI protocol */
+	const FCGI_VERSION_1 = 1;
+
+	/** [bytes] */
+	const FCGI_HEADER_LEN = 8;
+
+	/** Record types */
+	const
+		FCGI_BEGIN_REQUEST = 1,
+		#FCGI_ABORT_REQUEST = 2,
+		FCGI_END_REQUEST = 3,
+		FCGI_PARAMS = 4,
+		#FCGI_STDIN = 5,
+		FCGI_STDOUT = 6,
+		FCGI_STDERR = 7;
+		#FCGI_DATA = 8,
+		#FCGI_GET_VALUES = 9,
+		#FCGI_GET_VALUES_RESULT = 10,
+		#FCGI_UNKNOWN_TYPE = 11,
+		#FCGI_MAXTYPE = self::UNKNOWN_TYPE,
+
+		#NULL_REQUEST_ID = 0;
+
+	/** Keep socket opened for next request flag. */
+	const
+		FCGI_KEEP_CONN = 1;
+
+	/** Role of FastCGI server */
+	const
+		FCGI_RESPONDER = 1;
+		#AUTHORIZER = 2,
+		#FILTER = 3,
+
+	/** Request end protocol status */
+	const
+		FCGI_REQUEST_COMPLETE = 0,
+		FCGI_CANT_MPX_CONN = 1,
+		FCGI_OVERLOADED = 2,
+		FCGI_UNKNOWN_ROLE = 3;
+
+		#MAX_CONNS = 'FCGI_MAX_CONNS',
+		#MAX_REQS = 'FCGI_MAX_REQS',
+		#MPXS_CONNS = 'FCGI_MPXS_CONNS';
+
+	/** @internal */
+	const REQUEST_ID = 1;
+
+
+	/** @var string */
+	private $domain;
+
+	/** @var int */
+	private $port;
+
+	/** @var array */
+	private $iniValues = array();
+
+	/** @var resource */
+	private $socket;
+
+	/** @var string */
+	private $stdout;
+
+	/** @var string */
+	private $buffer = '';
+
+	/** @var stdClass */
+	private $header;
+
+
+	/**
+	 * @param  string  path to test file
+	 * @param  string  hostname or path to UNIX socket
+	 * @param  int  TCP port
+	 */
+	public function __construct($domain, $port = NULL)
+	{
+		$this->domain = $domain;
+		$this->port = $port;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getShortInfo()
+	{
+		return "FastCGI on $this->domain" . ($this->port ? ":$this->port" : '');
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getVersion()
+	{
+		return '9.9.9'; /** @todo */
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function hasXdebug()
+	{
+		return FALSE; /** @todo */
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function isCgi()
+	{
+		return TRUE;
+	}
+
+
+	/**
+	 * @param  string
+	 * @param  string
+	 */
+	public function setIniValue($name, $value)
+	{
+		$this->iniValues[$name] = $value;
+	}
+
+
+	/**
+	 * @inherit
+	 */
+	public function run($file, array $arguments, array $iniValues, array $envVars)
+	{
+		$this->socketOpen();
+
+		$params = array(
+			'GATEWAY_INTERFACE' => 'FastCGI/1.0',
+			'REQUEST_METHOD' => 'GET',
+			'SERVER_NAME' => php_uname('n'),
+			'SCRIPT_FILENAME' => $file,
+			'NETTE_TESTER_FCGI_ARGS' => serialize($arguments),  /** @todo */
+			'NETTE_TESTER_FCGI_INI' => serialize(array_merge($this->iniValues, $iniValues)),  /** @todo */
+		);
+
+		foreach ($envVars as $name => $value) {
+			$params[$name] = $value;
+		}
+
+		/* // POST data
+		$stdinLen = strlen($stdin);
+		if ($stdinLen) {
+			$params += array(
+				'CONTENT_LENGTH' => $stdinLen,
+			);
+		}*/
+
+
+		$raw = $this->encodeRecord(
+			self::FCGI_BEGIN_REQUEST,
+			self::REQUEST_ID,
+			$this->encodeBeginRequestBody(self::FCGI_RESPONDER, $keepAlive = FALSE)
+		);
+
+		$raw .= $this->encodeRecord(self::FCGI_PARAMS, self::REQUEST_ID, $this->encodeNameValues($params));
+		$raw .= $this->encodeRecord(self::FCGI_PARAMS, self::REQUEST_ID, '');
+
+		/*if ($stdinLen) {
+			$raw .= $this->encodeRecord(self::FCGI_STDIN, self::REQUEST_ID, $stdin);
+			$raw .= $this->encodeRecord(self::FCGI_STDIN, self::REQUEST_ID, '');
+		}*/
+
+		$this->socketWrite($raw);
+		$this->header = NULL;
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function isRunning()
+	{
+		if (!is_resource($this->socket)) {
+			return FALSE;
+		}
+
+		if ($this->header === NULL) {
+			try {
+				$this->header = $this->readHeader();
+			} catch (FastCGISocketShortReadException $e) {
+				return TRUE;
+			}
+		}
+
+		if ($this->header->id !== self::REQUEST_ID) {
+			throw new FastCGIException("Request ID " . self::REQUEST_ID . " expected but got '{$this->header->id}'.");
+		}
+
+
+		try {
+			$content = $this->socketRead($this->header->contentLength);
+		} catch (FastCGISocketShortReadException $e) {
+			return TRUE;
+		}
+
+		$padding = NULL;
+		while ($padding === NULL) {
+			try {
+				$padding = $this->socketRead($this->header->paddingLength);
+			} catch (FastCGISocketShortReadException $e) {
+				usleep(10000);
+			}
+		}
+
+
+		if ($this->header->type === self::FCGI_STDOUT) {
+			$this->stdout .= $content;
+
+		} elseif ($this->header->type === self::FCGI_STDERR) {
+			# drop stderr
+
+		} elseif ($this->header->type === self::FCGI_END_REQUEST) {
+			$requestEnd = $this->decodeEndRequestBody($content);
+
+			switch ($requestEnd->protocolStatus) {
+				case self::FCGI_REQUEST_COMPLETE:
+					break;
+
+				case self::FCGI_CANT_MPX_CONN:
+					throw new FastCGIException('FastCGI server cannot multiplex connections.');
+
+				case self::FCGI_OVERLOADED:
+					throw new FastCGIException('FastCGI server is overloaded.');
+
+				case self::FCGI_UNKNOWN_ROLE:
+					throw new FastCGIException('FastCGI server is not in RESPONDER role.');
+
+				default:
+					throw new FastCGIException("Unknown REQUEST_END protocol status: $requestEnd->protocolStatus");
+			}
+
+			fclose($this->socket);
+			$this->socket = NULL;
+			return FALSE;
+
+		} else {
+			throw new FastCGIException("Unexpected response type in header '{$this->header->type}'.");
+		}
+
+		$this->header = NULL;
+		return TRUE;
+	}
+
+
+	/**
+	 * @return array[int exitCode, string stdout]
+	 */
+	function getResult()
+	{
+		return array(0, $this->stdout);  /** @todo exitCode */
+	}
+
+
+
+	/** FastCGI protocol implementation ***************************************/
+	/**
+	 * @param  int
+	 * @param  int
+	 * @param  string
+	 * @return string
+	 * @see http://www.fastcgi.com/devkit/doc/fcgi-spec.html#S3.3
+	 */
+	private function encodeRecord($type, $id, $content)
+	{
+		return pack('CCnnCC',
+			self::FCGI_VERSION_1,
+			$type,
+			$id,
+			strlen($content),
+			0, # paddingLength
+			0  # reserved
+		) . $content;
+	}
+
+
+	/**
+	 * @param  int
+	 * @param  bool
+	 * @return string
+	 * @see http://www.fastcgi.com/devkit/doc/fcgi-spec.html#S5.1
+	 */
+	private function encodeBeginRequestBody($role, $keepAlive)
+	{
+		return pack('nC',
+			$role,
+			$keepAlive ? self::FCGI_KEEP_CONN : 0
+		) . str_repeat("\x00", 5);
+	}
+
+
+	/**
+	 * @param  string
+	 * @param  string
+	 * @return string
+	 * @see http://www.fastcgi.com/devkit/doc/fcgi-spec.html#S3.4
+	 */
+	private function encodeNameValue($name, $value)
+	{
+		$value = (string) $value;
+
+		$nLen = strlen($name);
+		$vLen = strlen($value);
+
+		return pack(($nLen < 128 ? 'C' : 'N') . ($vLen < 128 ? 'C' : 'N'),
+			$nLen < 128 ? $nLen : (0x80000000 | $nLen),
+			$vLen < 128 ? $vLen : (0x80000000 | $vLen)
+		) . $name . $value;
+	}
+
+
+	/**
+	 * @param  [name => value]
+	 * @return string
+	 */
+	private function encodeNameValues(array $values)
+	{
+		$encoded = '';
+		foreach ($values as $name => $value) {
+			$encoded .= $this->encodeNameValue($name, $value);
+		}
+		return $encoded;
+	}
+
+
+	/**
+	 * @return stdClass(version, type, id, contentLength, paddingLength)
+	 */
+	private function readHeader()
+	{
+		return (object) unpack(
+			'Cversion/Ctype/nid/ncontentLength/CpaddingLength',
+			$this->socketRead(self::FCGI_HEADER_LEN)
+		);
+	}
+
+
+	/**
+	 * @param  int
+	 * @return array
+	 */
+	private function readNameValues($length)
+	{
+		$variables = array();
+
+		$i = 0;
+		$raw = $this->socketRead($length);
+		while ($i < $length) {
+			$nLen = ord($raw[$i++]);
+			if ($nLen > 127) {
+				$nLen = ($nLen & 0x7F) << 24;
+				$nLen |= ord($raw[$i++]) << 16;
+				$nLen |= ord($raw[$i++]) << 8;
+				$nLen |= ord($raw[$i++]);
+			}
+
+			$vLen = ord($raw[$i++]);
+			if ($vLen > 127) {
+				$vLen = ($vLen & 0x7F) << 24;
+				$vLen |= ord($raw[$i++]) << 16;
+				$vLen |= ord($raw[$i++]) << 8;
+				$vLen |= ord($raw[$i++]);
+			}
+
+			$name = substr($raw, $i, $nLen);
+			$i += $nLen;
+
+			$value = substr($raw, $i, $vLen);
+			$i += $vLen;
+
+			$variables[$name] = $value;
+		}
+
+		return $variables;
+	}
+
+
+	/**
+	 * @param  string
+	 * @return stdClass(appStatus, protocolStatus)
+	 * @see http://www.fastcgi.com/devkit/doc/fcgi-spec.html#S5.5
+	 */
+	private function decodeEndRequestBody($raw)
+	{
+		return (object) unpack('NappStatus/CprotocolStatus', $raw);
+	}
+
+
+	/** Socket control ********************************************************/
+	/**
+	 * @param  bool
+	 */
+	private function socketOpen()
+	{
+		if ($this->socket !== NULL) {
+			throw new FastCGISocketException('Socket already opened.');
+		}
+
+		$socket = @fsockopen(
+			$this->port === NULL ? "unix://$this->domain" : $this->domain,
+			$this->port === NULL ? -1 : $this->port,
+			$errorCode,
+			$error
+		);
+
+		if ($socket === FALSE) {
+			throw new FastCGISocketException($error, $errorCode);
+		}
+
+		stream_set_blocking($socket, 0);
+		$this->socket = $socket;
+	}
+
+
+	/**
+	 * @param  int  requested lenght
+	 * @return string
+	 * @throws FastCGISocketException
+	 * @throws FastCGISocketShortReadException
+	 */
+	private function socketRead($length)
+	{
+		if ($length < 1) {
+			return '';
+		}
+
+		$tmp = @fread($this->socket, $length - $dataLen);
+		if ($tmp === FALSE) {
+			$error = error_get_last();
+			throw new FastCGISocketException($error['message']);
+		}
+		$this->buffer .= $tmp;
+
+		if (($bufferLen = strlen($this->buffer)) < $length) {
+			throw new FastCGISocketShortReadException("Reading of $length bytes failed, only $bufferLen read.");
+		}
+
+		$ret = substr($this->buffer, 0, $length);
+		$this->buffer = substr($this->buffer, $length);
+
+		return $ret;
+	}
+
+
+	/**
+	 * @param  string
+	 * @return void
+	 * @throws SocketException
+	 */
+	private function socketWrite($str)
+	{
+		$len = @fwrite($this->socket, $str);
+		if ($len === FALSE) {
+			$error = error_get_last();
+			throw new FastCGISocketException($error['message']);
+
+		} elseif ($len !== strlen($str)) {
+			throw new FastCGISocketException("Written " . strlen($str) . " bytes only, $length needed");
+		}
+	}
+
+}
+
+
+class FastCGIException extends \RuntimeException
+{
+}
+
+
+class FastCGISocketException extends FastCGIException
+{
+}
+
+
+class FastCGISocketShortReadException extends FastCGISocketException
+{
+}

--- a/Tester/Runner/IPhpInterpreter.php
+++ b/Tester/Runner/IPhpInterpreter.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the Nette Tester.
+ * Copyright (c) 2009 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Tester\Runner;
+
+
+/**
+ * PHP interpreter interface.
+ *
+ * @author     David Grudl
+ * @author     Miloslav Hůla
+ */
+interface IPhpInterpreter
+{
+}

--- a/Tester/Runner/IPhpInterpreter.php
+++ b/Tester/Runner/IPhpInterpreter.php
@@ -16,4 +16,55 @@ namespace Tester\Runner;
  */
 interface IPhpInterpreter
 {
+	/**
+	 * Get single line human readable info.
+	 * @return string
+	 */
+	function getShortInfo();
+
+	/**
+	 * @return string
+	 */
+	function getVersion();
+
+
+	/**
+	 * @return bool
+	 */
+	function hasXdebug();
+
+
+	/**
+	 * @return bool
+	 */
+	function isCgi();
+
+
+	/**
+	 * @param  string
+	 * @param  string
+	 */
+	function setIniValue($name, $value);
+
+
+	/**
+	 * @param  string  PHP script to run path
+	 * @param  string  script arguments
+	 * @param  array  PHP INI values
+	 * @param  array  system environmental variables
+	 */
+	function run($file, array $arguments, array $iniValues, array $envVars);
+
+
+	/**
+	 * @return bool
+	 */
+	function isRunning();
+
+
+	/**
+	 * @return array[int exitCode, string stdout]
+	 */
+	function getResult();
+
 }

--- a/Tester/Runner/Job.php
+++ b/Tester/Runner/Job.php
@@ -39,7 +39,7 @@ class Job
 	/** @var string  output headers in raw format */
 	private $headers;
 
-	/** @var PhpExecutable */
+	/** @var IPhpInterpreter */
 	private $php;
 
 	/** @var resource */
@@ -56,7 +56,7 @@ class Job
 	 * @param  string  test file name
 	 * @return void
 	 */
-	public function __construct($testFile, PhpExecutable $php, $args = NULL)
+	public function __construct($testFile, IPhpInterpreter $php, $args = NULL)
 	{
 		$this->file = (string) $testFile;
 		$this->php = $php;

--- a/Tester/Runner/Job.php
+++ b/Tester/Runner/Job.php
@@ -62,7 +62,7 @@ class Job
 	public function __construct($testFile, IPhpInterpreter $php, array $args = array())
 	{
 		$this->file = (string) $testFile;
-		$this->php = $php;
+		$this->php = clone $php; /** @todo Clone? */
 		$this->args = $args;
 	}
 

--- a/Tester/Runner/Output/ConsolePrinter.php
+++ b/Tester/Runner/Output/ConsolePrinter.php
@@ -42,7 +42,7 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 	{
 		$this->time = -microtime(TRUE);
 		echo 'PHP ' . $this->runner->getPhp()->getVersion()
-			. ' | ' . $this->runner->getPhp()->getCommandLine()
+			. ' | ' . $this->runner->getPhp()->getShortInfo()
 			. " | {$this->runner->threadCount} thread" . ($this->runner->threadCount > 1 ? 's' : '') . "\n\n";
 	}
 

--- a/Tester/Runner/Output/Logger.php
+++ b/Tester/Runner/Output/Logger.php
@@ -35,7 +35,7 @@ class Logger implements Tester\Runner\OutputHandler
 	public function begin()
 	{
 		fputs($this->file, 'PHP ' . $this->runner->getPhp()->getVersion()
-			. ' | ' . $this->runner->getPhp()->getCommandLine()
+			. ' | ' . $this->runner->getPhp()->getShortInfo()
 			. " | {$this->runner->threadCount} threads\n\n");
 	}
 

--- a/Tester/Runner/Runner.php
+++ b/Tester/Runner/Runner.php
@@ -34,7 +34,7 @@ class Runner
 	/** @var OutputHandler[] */
 	public $outputHandlers = array();
 
-	/** @var PhpExecutable */
+	/** @var IPhpInterpreter */
 	private $php;
 
 	/** @var Job[] */
@@ -50,7 +50,7 @@ class Runner
 	private $interrupted;
 
 
-	public function __construct(PhpExecutable $php)
+	public function __construct(IPhpInterpreter $php)
 	{
 		$this->php = $php;
 		$this->testHandler = new TestHandler($this);
@@ -158,7 +158,7 @@ class Runner
 
 
 	/**
-	 * @return PhpExecutable
+	 * @return IPhpInterpreter
 	 */
 	public function getPhp()
 	{

--- a/Tester/Runner/TestHandler.php
+++ b/Tester/Runner/TestHandler.php
@@ -94,7 +94,7 @@ class TestHandler
 	}
 
 
-	private function initiatePhpVersion($version, PhpExecutable $php)
+	private function initiatePhpVersion($version, IPhpInterpreter $php)
 	{
 		if (preg_match('#^(<=|<|==|=|!=|<>|>=|>)?\s*(.+)#', $version, $matches)
 			&& version_compare($matches[2], $php->getVersion(), $matches[1] ?: '>='))
@@ -104,13 +104,13 @@ class TestHandler
 	}
 
 
-	private function initiatePhpIni($value, PhpExecutable $php)
+	private function initiatePhpIni($value, IPhpInterpreter $php)
 	{
 		$php->arguments .= ' -d ' . Helpers::escapeArg($value);
 	}
 
 
-	private function initiateDataProvider($provider, PhpExecutable $php, $file)
+	private function initiateDataProvider($provider, IPhpInterpreter $php, $file)
 	{
 		try {
 			list($dataFile, $query, $optional) = Tester\DataProvider::parseAnnotation($provider, $file);
@@ -126,7 +126,7 @@ class TestHandler
 	}
 
 
-	private function initiateMultiple($count, PhpExecutable $php, $file)
+	private function initiateMultiple($count, IPhpInterpreter $php, $file)
 	{
 		foreach (range(0, (int) $count - 1) as $arg) {
 			$this->runner->addJob(new Job($file, $php, (string) $arg));
@@ -135,7 +135,7 @@ class TestHandler
 	}
 
 
-	private function initiateTestCase($foo, PhpExecutable $php, $file)
+	private function initiateTestCase($foo, IPhpInterpreter $php, $file)
 	{
 		$job = new Job($file, $php, Helpers::escapeArg(Tester\TestCase::LIST_METHODS));
 		$job->run();

--- a/Tester/Runner/TestHandler.php
+++ b/Tester/Runner/TestHandler.php
@@ -67,7 +67,7 @@ class TestHandler
 	public function assess(Job $job)
 	{
 		list($annotations, $testName) = $this->getAnnotations($job->getFile());
-		$testName .= (strlen($job->getArguments()) ? " [{$job->getArguments()}]" : '');
+		$testName .= (count($job->getArguments()) ? ' [' . implode(' ', $job->getArguments()) . ']' : '');
 		$annotations += array(
 			'exitcode' => Job::CODE_OK,
 			'httpcode' => self::HTTP_OK,
@@ -106,7 +106,8 @@ class TestHandler
 
 	private function initiatePhpIni($value, IPhpInterpreter $php)
 	{
-		$php->arguments .= ' -d ' . Helpers::escapeArg($value);
+		list($name, $value) = explode('=', $value);
+		$php->setIniValue(trim($name), trim($value));
 	}
 
 
@@ -120,7 +121,7 @@ class TestHandler
 		}
 
 		foreach (array_keys($data) as $item) {
-			$this->runner->addJob(new Job($file, $php, Helpers::escapeArg($item) . ' ' . Helpers::escapeArg($dataFile)));
+			$this->runner->addJob(new Job($file, $php, array($item, $dataFile)));
 		}
 		return TRUE;
 	}
@@ -129,7 +130,7 @@ class TestHandler
 	private function initiateMultiple($count, IPhpInterpreter $php, $file)
 	{
 		foreach (range(0, (int) $count - 1) as $arg) {
-			$this->runner->addJob(new Job($file, $php, (string) $arg));
+			$this->runner->addJob(new Job($file, $php, array((string) $arg)));
 		}
 		return TRUE;
 	}
@@ -137,7 +138,7 @@ class TestHandler
 
 	private function initiateTestCase($foo, IPhpInterpreter $php, $file)
 	{
-		$job = new Job($file, $php, Helpers::escapeArg(Tester\TestCase::LIST_METHODS));
+		$job = new Job($file, $php, array(Tester\TestCase::LIST_METHODS));
 		$job->run();
 
 		if (in_array($job->getExitCode(), array(Job::CODE_ERROR, Job::CODE_FAIL, Job::CODE_SKIP))) {
@@ -152,7 +153,7 @@ class TestHandler
 		}
 
 		foreach ($methods as $method) {
-			$this->runner->addJob(new Job($file, $php, Helpers::escapeArg($method)));
+			$this->runner->addJob(new Job($file, $php, array($method)));
 		}
 		return TRUE;
 	}

--- a/Tester/Runner/ZendPhpBinary.php
+++ b/Tester/Runner/ZendPhpBinary.php
@@ -9,11 +9,11 @@ namespace Tester\Runner;
 
 
 /**
- * PHP executable command-line.
+ * Zend PHP executable command-line.
  *
  * @author     David Grudl
  */
-class PhpExecutable
+class ZendPhpBinary implements IPhpInterpreter //PhpExecutable
 {
 	/** @var string  PHP arguments */
 	public $arguments;

--- a/Tester/Runner/ZendPhpBinary.php
+++ b/Tester/Runner/ZendPhpBinary.php
@@ -7,16 +7,18 @@
 
 namespace Tester\Runner;
 
+use Tester\Helpers;
+
 
 /**
  * Zend PHP executable command-line.
  *
  * @author     David Grudl
  */
-class ZendPhpBinary implements IPhpInterpreter //PhpExecutable
+class ZendPhpBinary implements IPhpInterpreter
 {
 	/** @var string  PHP arguments */
-	public $arguments;
+	private $commandLineArgs;
 
 	/** @var string  PHP executable */
 	private $path;
@@ -24,18 +26,31 @@ class ZendPhpBinary implements IPhpInterpreter //PhpExecutable
 	/** @var string  PHP version */
 	private $version;
 
-	/** @var bool is CGI? */
+	/** @var bool  is CGI? */
 	private $cgi;
 
-	/** @var bool */
+	/** @var bool  has Xdebug? */
 	private $xdebug;
 
 
-	public function __construct($path, $args = NULL)
+	/** @var resource */
+	private $proc;
+
+	/** @var resource */
+	private $stdout;
+
+	/** @var int */
+	private $exitCode;
+
+	/** @var string */
+	private $output;
+
+
+	public function __construct($path, $commandLineArgs = NULL)
 	{
-		$this->path = \Tester\Helpers::escapeArg($path);
+		$this->path = Helpers::escapeArg($path);
 		$proc = @proc_open(
-			"$this->path -n $args -v", // -v must be the last
+			"$this->path -n $commandLineArgs -v", // -v must be the last
 			array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w')),
 			$pipes,
 			NULL,
@@ -53,16 +68,16 @@ class ZendPhpBinary implements IPhpInterpreter //PhpExecutable
 		$this->version = $matches[1];
 		$this->cgi = strcasecmp($matches[2], 'g') === 0;
 		$this->xdebug = strpos($output, 'Xdebug') > 0;
-		$this->arguments = $args;
+		$this->commandLineArgs = $commandLineArgs;
 	}
 
 
 	/**
 	 * @return string
 	 */
-	public function getCommandLine()
+	public function getShortInfo()
 	{
-		return $this->path . ' ' . $this->arguments;
+		return $this->path . ' ' . $this->commandLineArgs;
 	}
 
 
@@ -90,6 +105,92 @@ class ZendPhpBinary implements IPhpInterpreter //PhpExecutable
 	public function isCgi()
 	{
 		return $this->cgi;
+	}
+
+
+	/**
+	 * @param  string
+	 * @param  string	 
+	 */
+	public function setIniValue($name, $value)
+	{
+		$this->commandLineArgs = trim($this->commandLineArgs . ' -d ' . Helpers::escapeArg("$name=$value"));
+	}
+
+
+	/**
+	 * @inherit
+	 */
+	public function run($file, array $arguments, array $iniValues, array $envVars)
+	{
+		foreach ($envVars as $name => $value) {
+			putenv($name . '=' . $value);
+		}
+
+		$cmd = array($this->path);
+		$cmd[] = '-n';
+		$cmd[] = $this->commandLineArgs;
+
+		foreach ($iniValues as $name => $value) {
+			$cmd[] = '-d ' . Helpers::escapeArg("$name=$value");
+		}
+
+		$cmd[] = Helpers::escapeArg($file);
+
+		foreach ($arguments as $arg) {
+			$cmd[] = Helpers::escapeArg($arg);
+		}
+
+		$this->proc = proc_open(
+			implode(' ', $cmd),
+			array(
+				array('pipe', 'r'),
+				array('pipe', 'w'),
+				array('pipe', 'w'),
+			),
+			$pipes,
+			dirname($file),
+			NULL,
+			array('bypass_shell' => TRUE)
+		);
+		list($stdin, $this->stdout, $stderr) = $pipes;
+		fclose($stdin);
+		fclose($stderr);
+		stream_set_blocking($this->stdout, 0);
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function isRunning()
+	{
+		if (!is_resource($this->stdout)) {
+			return FALSE;
+		}
+
+		$this->output .= stream_get_contents($this->stdout);
+		$status = proc_get_status($this->proc);
+		if ($status['running']) {
+			return TRUE;
+		}
+
+		fclose($this->stdout);
+		$code = proc_close($this->proc);
+		$this->exitCode = $code === -1  /** @todo Where to place exit code constants? */
+			? $status['exitcode']
+			: $code;
+
+		return FALSE;
+	}
+
+
+	/**
+	 * @return array[int exitCode, string stdout]
+	 */
+	function getResult()
+	{
+		return array($this->exitCode, $this->output);
 	}
 
 }

--- a/Tester/tester.php
+++ b/Tester/tester.php
@@ -111,7 +111,7 @@ if ($options['--info']) {
 
 if ($options['--coverage']) {
 	if (!$php->hasXdebug()) {
-		throw new Exception("Code coverage functionality requires Xdebug extension (used {$php->getCommandLine()})");
+		throw new Exception("Code coverage functionality requires Xdebug extension");
 	}
 	file_put_contents($options['--coverage'], '');
 	$coverageFile = realpath($options['--coverage']);

--- a/Tester/tester.php
+++ b/Tester/tester.php
@@ -6,7 +6,8 @@
  */
 
 
-require __DIR__ . '/Runner/PhpExecutable.php';
+require __DIR__ . '/Runner/IPhpInterpreter.php';
+require __DIR__ . '/Runner/ZendPhpBinary.php';
 require __DIR__ . '/Runner/Runner.php';
 require __DIR__ . '/Runner/Job.php';
 require __DIR__ . '/Runner/CommandLine.php';
@@ -99,7 +100,7 @@ foreach ($options['-d'] as $item) {
 	$phpArgs .= ' -d ' . Tester\Helpers::escapeArg($item);
 }
 
-$php = new Tester\Runner\PhpExecutable($options['-p'], $phpArgs);
+$php = new Tester\Runner\ZendPhpBinary($options['-p'], $phpArgs);
 
 if ($options['--info']) {
 	$job = new Tester\Runner\Job(__DIR__ . '/Runner/info.php', $php);

--- a/Tester/tester.php
+++ b/Tester/tester.php
@@ -8,6 +8,7 @@
 
 require __DIR__ . '/Runner/IPhpInterpreter.php';
 require __DIR__ . '/Runner/ZendPhpBinary.php';
+require __DIR__ . '/Runner/FastCGIPhpSocket.php';
 require __DIR__ . '/Runner/Runner.php';
 require __DIR__ . '/Runner/Job.php';
 require __DIR__ . '/Runner/CommandLine.php';
@@ -100,7 +101,15 @@ foreach ($options['-d'] as $item) {
 	$phpArgs .= ' -d ' . Tester\Helpers::escapeArg($item);
 }
 
-$php = new Tester\Runner\ZendPhpBinary($options['-p'], $phpArgs);
+if (strpos($options['-p'], ':') === FALSE) {
+	$php = new Tester\Runner\ZendPhpBinary($options['-p'], $phpArgs);
+} else {
+	if ($options['-c']) {
+		throw new \Exception("Option -c does not work with FastCGI.");
+	}
+	list($domain, $port) = explode(':', $options['-p']);
+	$php = new Tester\Runner\FastCGIPhpSocket($domain, $port);
+}
 
 if ($options['--info']) {
 	$job = new Tester\Runner\Job(__DIR__ . '/Runner/info.php', $php);

--- a/tests/Runner.annotations.phpt
+++ b/tests/Runner.annotations.phpt
@@ -6,7 +6,8 @@ use Tester\Assert,
 require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/../Tester/Runner/OutputHandler.php';
 require __DIR__ . '/../Tester/Runner/TestHandler.php';
-require __DIR__ . '/../Tester/Runner/PhpExecutable.php';
+require __DIR__ . '/../Tester/Runner/IPhpInterpreter.php';
+require __DIR__ . '/../Tester/Runner/ZendPhpBinary.php';
 require __DIR__ . '/../Tester/Runner/Runner.php';
 
 if (PHP_VERSION_ID < 50400) {
@@ -27,7 +28,7 @@ class Logger implements Tester\Runner\OutputHandler
 	function end() {}
 }
 
-$php = new Tester\Runner\PhpExecutable(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
+$php = new Tester\Runner\ZendPhpBinary(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
 $runner = new Tester\Runner\Runner($php);
 $runner->paths[] = __DIR__ . '/annotations/*.phptx';
 $runner->outputHandlers[] = $logger = new Logger;

--- a/tests/Runner.edge.phpt
+++ b/tests/Runner.edge.phpt
@@ -6,7 +6,8 @@ use Tester\Assert,
 require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/../Tester/Runner/OutputHandler.php';
 require __DIR__ . '/../Tester/Runner/TestHandler.php';
-require __DIR__ . '/../Tester/Runner/PhpExecutable.php';
+require __DIR__ . '/../Tester/Runner/IPhpInterpreter.php';
+require __DIR__ . '/../Tester/Runner/ZendPhpBinary.php';
 require __DIR__ . '/../Tester/Runner/Runner.php';
 
 if (PHP_VERSION_ID < 50400) {
@@ -27,7 +28,7 @@ class Logger implements Tester\Runner\OutputHandler
 	function end() {}
 }
 
-$php = new Tester\Runner\PhpExecutable(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
+$php = new Tester\Runner\ZendPhpBinary(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
 $runner = new Tester\Runner\Runner($php);
 $runner->paths[] = __DIR__ . '/edge/*.phptx';
 $runner->outputHandlers[] = $logger = new Logger;

--- a/tests/Runner.multiple-fails.phpt
+++ b/tests/Runner.multiple-fails.phpt
@@ -30,7 +30,8 @@ class Logger implements Tester\Runner\OutputHandler
 }
 
 $php = new Tester\Runner\ZendPhpBinary(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
-$php->arguments .= ' -d display_errors=On -d html_errors=Off';
+$php->setIniValue('display_errors', 'on');
+$php->setIniValue('html_errors', 'off');
 
 $runner = new Runner($php);
 $runner->paths[] = __DIR__ . '/multiple-fails/*.phptx';

--- a/tests/Runner.multiple-fails.phpt
+++ b/tests/Runner.multiple-fails.phpt
@@ -7,7 +7,8 @@ use Tester\Assert,
 require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/../Tester/Runner/OutputHandler.php';
 require __DIR__ . '/../Tester/Runner/TestHandler.php';
-require __DIR__ . '/../Tester/Runner/PhpExecutable.php';
+require __DIR__ . '/../Tester/Runner/IPhpInterpreter.php';
+require __DIR__ . '/../Tester/Runner/ZendPhpBinary.php';
 require __DIR__ . '/../Tester/Runner/Runner.php';
 
 if (PHP_VERSION_ID < 50400) {
@@ -28,7 +29,7 @@ class Logger implements Tester\Runner\OutputHandler
 	function end() {}
 }
 
-$php = new Tester\Runner\PhpExecutable(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
+$php = new Tester\Runner\ZendPhpBinary(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
 $php->arguments .= ' -d display_errors=On -d html_errors=Off';
 
 $runner = new Runner($php);

--- a/tests/Runner.multiple.phpt
+++ b/tests/Runner.multiple.phpt
@@ -31,16 +31,16 @@ sort($tests);
 $path = __DIR__ . DIRECTORY_SEPARATOR . 'multiple' . DIRECTORY_SEPARATOR;
 
 Assert::same(array(
-	array('dataProvider.phptx', Helpers::escapeArg('bar') . ' ' . Helpers::escapeArg("$path../fixtures/dataprovider.ini")),
-	array('dataProvider.phptx', Helpers::escapeArg('foo') . ' ' . Helpers::escapeArg("$path../fixtures/dataprovider.ini")),
-	array('dataProvider.query.phptx', Helpers::escapeArg('foo 2.2.3') . ' ' . Helpers::escapeArg("$path../fixtures/dataprovider.query.ini")),
-	array('dataProvider.query.phptx', Helpers::escapeArg('foo 3 xxx') . ' ' . Helpers::escapeArg("$path../fixtures/dataprovider.query.ini")),
-	array('multiple.phptx', '0'),
-	array('multiple.phptx', '1'),
-	array('testcase.phptx', Helpers::escapeArg('test1')),
-	array('testcase.phptx', Helpers::escapeArg('testBar')),
-	array('testcase.phptx', Helpers::escapeArg('testFoo')),
-	array('testcase.phptx', Helpers::escapeArg('testPrivate')),
-	array('testcase.phptx', Helpers::escapeArg('testProtected')),
-	array('testcase.phptx', Helpers::escapeArg('test_foo')),
+	array('dataProvider.phptx', array('bar', "$path../fixtures/dataprovider.ini")),
+	array('dataProvider.phptx', array('foo', "$path../fixtures/dataprovider.ini")),
+	array('dataProvider.query.phptx', array('foo 2.2.3', "$path../fixtures/dataprovider.query.ini")),
+	array('dataProvider.query.phptx', array('foo 3 xxx', "$path../fixtures/dataprovider.query.ini")),
+	array('multiple.phptx', array('0')),
+	array('multiple.phptx', array('1')),
+	array('testcase.phptx', array('test1')),
+	array('testcase.phptx', array('testBar')),
+	array('testcase.phptx', array('testFoo')),
+	array('testcase.phptx', array('testPrivate')),
+	array('testcase.phptx', array('testProtected')),
+	array('testcase.phptx', array('test_foo')),
 ), $tests);

--- a/tests/Runner.multiple.phpt
+++ b/tests/Runner.multiple.phpt
@@ -5,7 +5,8 @@ use Tester\Assert,
 
 require __DIR__ . '/bootstrap.php';
 require __DIR__ . '/../Tester/Runner/TestHandler.php';
-require __DIR__ . '/../Tester/Runner/PhpExecutable.php';
+require __DIR__ . '/../Tester/Runner/IPhpInterpreter.php';
+require __DIR__ . '/../Tester/Runner/ZendPhpBinary.php';
 require __DIR__ . '/../Tester/Runner/Runner.php';
 
 if (PHP_VERSION_ID < 50400) {
@@ -13,7 +14,7 @@ if (PHP_VERSION_ID < 50400) {
 }
 
 
-$php = new Tester\Runner\PhpExecutable(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
+$php = new Tester\Runner\ZendPhpBinary(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
 $runner = new Tester\Runner\Runner($php);
 
 $tests = Assert::with($runner, function() {

--- a/tests/ZendPhpBinary.phpt
+++ b/tests/ZendPhpBinary.phpt
@@ -7,10 +7,11 @@
 use Tester\Assert;
 
 require __DIR__ . '/bootstrap.php';
-require __DIR__ . '/../Tester/Runner/PhpExecutable.php';
+require __DIR__ . '/../Tester/Runner/IPhpInterpreter.php';
+require __DIR__ . '/../Tester/Runner/ZendPhpBinary.php';
 
 
-$php = new Tester\Runner\PhpExecutable(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
+$php = new Tester\Runner\ZendPhpBinary(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
 
 Assert::contains(PHP_BINARY, $php->getCommandLine());
 Assert::same(PHP_VERSION, $php->getVersion());

--- a/tests/ZendPhpBinary.phpt
+++ b/tests/ZendPhpBinary.phpt
@@ -13,7 +13,6 @@ require __DIR__ . '/../Tester/Runner/ZendPhpBinary.php';
 
 $php = new Tester\Runner\ZendPhpBinary(PHP_BINARY, '-c ' . Tester\Helpers::escapeArg(php_ini_loaded_file()));
 
-Assert::contains(PHP_BINARY, $php->getCommandLine());
 Assert::same(PHP_VERSION, $php->getVersion());
 Assert::same(extension_loaded('xdebug'), $php->hasXdebug());
 Assert::same(strpos(PHP_SAPI, 'cgi') !== FALSE, $php->isCgi());


### PR DESCRIPTION
This is an unfinished experiment, few months old. I just want to share the idea:
- run PHP or HHVM as FastCGI listening on port/socket
- run tester for example as `-p 127.0.0.1:9000`

There are crucial priblems (all workarounds you can find in `Environment` class):
- cannot get the script exit code, FastCGI protocol has options for it, but it is not supported by PHP (I didn't test HHVM)
- only runtime changeable INI values can be passed
- `$_SERVER['argv']` support

So, I don't know if there is chance to finish it to usable state.

You can try it, all Tester's tests pass me now under PHP-FCGI and HHVM too, but I'm sure that it is an illusion.

Now it is a nice toy :-)
