### PR TITLE
DomQuery: added support for HTML5 elements

### DIFF
--- a/Tester/Framework/DomQuery.php
+++ b/Tester/Framework/DomQuery.php
@@ -24,8 +24,23 @@ class DomQuery extends \SimpleXMLElement
 		if (strpos($html, '<') === FALSE) {
 			$html = '<body>' . $html;
 		}
+
+		$html = preg_replace('#<(keygen|source|track|wbr)(?=\s|>)("[^"]*"|\'[^\']*\'|[^"\'>]+)*+(?<!/)>#', '<$1$2 />', $html);
+
 		$dom = new \DOMDocument();
+		$old = libxml_use_internal_errors(TRUE);
+		libxml_clear_errors();
 		$dom->loadHTML($html);
+		$errors = libxml_get_errors();
+		libxml_use_internal_errors($old);
+
+		$re = '#Tag (article|aside|audio|bdi|canvas|data|datalist|figcaption|figure|footer|header|keygen|main|mark'
+			. '|meter|nav|output|progress|rb|rp|rt|rtc|ruby|section|source|template|time|track|video|wbr) invalid#';
+		foreach ($errors as $error) {
+			if (!preg_match($re, $error->message)) {
+				trigger_error(__METHOD__ . ": $error->message on line $error->line.", E_USER_WARNING);
+			}
+		}
 		return simplexml_import_dom($dom, __CLASS__);
 	}
 

--- a/tests/DomQuery.fromHtml.phpt
+++ b/tests/DomQuery.fromHtml.phpt
@@ -8,3 +8,14 @@ require __DIR__ . '/bootstrap.php';
 $q = DomQuery::fromHtml('hello');
 Assert::true( $q->has('body') );
 Assert::false( $q->has('p') );
+
+
+$q = DomQuery::fromHtml('<track data=val><footer data-abc=val>hello</footer>');
+Assert::true( $q->has('footer') );
+Assert::true( $q->has('footer[data-abc]') );
+Assert::false( $q->has('footer[id]') );
+
+Assert::true( $q->has('track') );
+Assert::true( $q->has('track[data]') );
+Assert::false( $q->has('track[id]') );
+Assert::false( $q->has('track footer') );


### PR DESCRIPTION
~~Except empty elements, like `wbr` or `command`.~~
