### PR TITLE
added Tester\FileMock

### DIFF
--- a/Tester/Framework/FileMock.php
+++ b/Tester/Framework/FileMock.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * This file is part of the Nette Tester.
+ * Copyright (c) 2009 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Tester;
+
+
+/**
+ * Mock files.
+ */
+class FileMock
+{
+	const PROTOCOL = 'mock';
+
+	/** @var string[] */
+	public static $files = array();
+
+	/** @var string */
+	private $content;
+
+	/** @var int */
+	private $pos;
+
+
+	/**
+	 * @return string  file name
+	 */
+	public static function create($content, $extension = NULL)
+	{
+		if (!self::$files) {
+			stream_wrapper_register(self::PROTOCOL, __CLASS__);
+		}
+		$name = self::PROTOCOL . '://' . uniqid() . '.' . $extension;
+		self::$files[$name] = $content;
+		return $name;
+	}
+
+
+	public function stream_open($path, $mode, $options, &$opened_path)
+	{
+		$this->content = & self::$files[$path];
+		$this->pos = 0;
+		return TRUE;
+	}
+
+
+	public function stream_read($len)
+	{
+		$res = substr($this->content, $this->pos, $len);
+		$this->pos += strlen($res);
+		return $res;
+	}
+
+
+	public function stream_write($data)
+	{
+		$this->content = substr($this->content, 0, $this->pos)
+			. str_repeat("\x00", max(0, $this->pos - strlen($this->content)))
+			. $data
+			. substr($this->content, $this->pos + strlen($data));
+		$this->pos += strlen($data);
+		return strlen($data);
+	}
+
+
+	public function stream_tell()
+	{
+		return $this->pos;
+	}
+
+
+	public function stream_eof()
+	{
+		return $this->pos >= strlen($this->content);
+	}
+
+
+	public function stream_seek($offset, $whence)
+	{
+		if ($whence === SEEK_CUR) {
+			$offset += $this->pos;
+		} elseif ($whence === SEEK_END) {
+			$offset += strlen($this->content);
+		}
+		if ($offset >= 0) {
+			$this->pos = $offset;
+			return TRUE;
+		} else {
+			return FALSE;
+		}
+	}
+
+
+	public function stream_truncate($size)
+	{
+		$this->content = (string) substr($this->content, 0, $size)
+			. str_repeat("\x00", max(0, $size - strlen($this->content)));
+		return TRUE;
+	}
+
+
+	public function stream_stat()
+	{
+		return array('mode' => 0100000, 'size' => strlen($this->content));
+	}
+
+
+	public function url_stat($path, $flags)
+	{
+		return isset(self::$files[$path])
+			? array('mode' => 0100000, 'size' => strlen(self::$files[$path]))
+			: FALSE;
+	}
+
+}

--- a/Tester/bootstrap.php
+++ b/Tester/bootstrap.php
@@ -9,6 +9,7 @@ require __DIR__ . '/Framework/Environment.php';
 require __DIR__ . '/Framework/DataProvider.php';
 require __DIR__ . '/Framework/Assert.php';
 require __DIR__ . '/Framework/Dumper.php';
+require __DIR__ . '/Framework/FileMock.php';
 require __DIR__ . '/Framework/TestCase.php';
 require __DIR__ . '/Framework/DomQuery.php';
 require __DIR__ . '/CodeCoverage/Collector.php';

--- a/tests/FileMock.phpt
+++ b/tests/FileMock.phpt
@@ -1,0 +1,56 @@
+<?php
+
+use Tester\Assert,
+	Tester\FileMock;
+
+require __DIR__ . '/bootstrap.php';
+
+
+test(function() {
+	$f = fopen($name = FileMock::create('', 'txt'), 'w+');
+
+	Assert::match('%a%.txt', $name);
+	Assert::true(is_file($name));
+	Assert::false(is_file($name . 'unknown'));
+	Assert::same(0, filesize($name));
+	Assert::true(feof($f));
+
+	Assert::same(5, fwrite($f, 'hello'));
+	Assert::same(6, fwrite($f, ' world'));
+	Assert::same('hello world', file_get_contents($name));
+
+	Assert::true(feof($f));
+	Assert::same(11, ftell($f));
+
+	Assert::same(0, fseek($f, 1));
+	Assert::false(feof($f));
+	Assert::same(1, ftell($f));
+
+	Assert::same(0, fseek($f, -1, SEEK_END));
+	Assert::false(feof($f));
+	Assert::same(10, ftell($f));
+
+	Assert::same(0, fseek($f, -1, SEEK_CUR));
+	Assert::same(9, ftell($f));
+
+	Assert::same('l', fread($f, 1));
+	Assert::same('d', fread($f, 1000));
+	Assert::same(11, ftell($f));
+
+	Assert::same(0, fseek($f, 3, SEEK_END));
+	Assert::same(1, fwrite($f, '!'));
+	Assert::same("hello world\x00\x00\x00!", file_get_contents($name));
+
+	if (PHP_VERSION_ID >= 50400) {
+		Assert::true(ftruncate($f, 5));
+		Assert::same(15, ftell($f));
+		Assert::same('hello', file_get_contents($name));
+	}
+
+	fclose($f);
+});
+
+
+test(function() {
+	Assert::same(123, require FileMock::create('<?php return 123;'));
+});


### PR DESCRIPTION
Allowes to test functions like `parse_ini_file()`:

``` php
Assert::same(
    array('key' => 'value'), 
    parse_ini_file(FileMock::create('key=value'))
);
```
