### PR TITLE
Extension iconv is not required

### DIFF
--- a/Tester/Framework/Dumper.php
+++ b/Tester/Framework/Dumper.php
@@ -53,7 +53,7 @@ class Dumper
 			return strpos($var, '.') === FALSE ? $var . '.0' : $var;
 
 		} elseif (is_string($var)) {
-			if (@iconv_strlen($var, 'UTF-8') > self::$maxLength) {
+			if (extension_loaded('iconv') && @iconv_strlen($var, 'UTF-8') > self::$maxLength) { // @ - invalid UTF-8 sequence notice
 				$var = iconv_substr($var, 0, self::$maxLength, 'UTF-8') . '...';
 			} elseif (strlen($var) > self::$maxLength) {
 				$var = substr($var, 0, self::$maxLength) . '...';

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,10 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.0",
-		"ext-iconv": "*"
+		"php": ">=5.3.0"
+	},
+	"suggest": {
+		"ext-iconv": "For better UTF-8 strings dumping."
 	},
 	"autoload": {
 		"classmap": ["Tester/"]


### PR DESCRIPTION
Even the composer.json may require PHP extension, the PHP binary running tests may be completely different.

See the error message in [this](http://forum.nette.org/cs/20539-tester-w-spousti-testy-sebe-sama#p141027) topic.
