### PR TITLE
Add Assert::command() assertion

### DIFF
--- a/Tester/Framework/Assert.php
+++ b/Tester/Framework/Assert.php
@@ -417,6 +417,28 @@ class Assert
 
 
 	/**
+	 * Checks if the command exits with code.
+	 * @param  string
+	 * @param  integer
+	 * @return string  command output
+	 */
+	public static function command($command, $exitCode = 0)
+	{
+		self::$counter++;
+
+		ob_start();
+		system($command, $code);
+		$output = ob_get_clean();
+
+		if ($code !== $exitCode) {
+			self::fail('Exit code %2 was expected but got %1', $code, $exitCode);
+		}
+
+		return $output;
+	}
+
+
+	/**
 	 * Failed assertion
 	 * @return void
 	 */

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ This table shows all assertions (class `Assert` means `Tester\Assert`):
 - `Assert::match($pattern, $value)` - Compares result using regular expression or mask.
 - `Assert::matchFile($file, $value)` - Compares result using regular expression or mask sorted in file.
 - `Assert::count($count, $value)` - Reports an error if number of items in $value is not $count.
+- `Assert::command($command, $exitCode)` - Reports an error if exit code does not match. Returns the command output.
 
 Testing exceptions:
 

--- a/tests/Assert.command.phpt
+++ b/tests/Assert.command.phpt
@@ -1,0 +1,17 @@
+<?php
+
+use Tester\Assert;
+
+require __DIR__ . '/bootstrap.php';
+
+
+$command = defined('PHP_WINDOWS_VERSION_BUILD')
+	? 'dir'
+	: 'ls';
+
+$output = Assert::command($command);
+Assert::match('%A%Assert.command.phpt%A%', $output);
+
+Assert::exception(function() use ($command) {
+	Assert::command($command, 10);
+}, 'Tester\AssertException', 'Exit code 10 was expected but got 0');


### PR DESCRIPTION
It is useful for user's binaries easy check. But I cannot decide:

<del>1) parameters order; isn't `command($command, $output = NULL, $exitCode = 0)` better?</del>


<del>2) what about let out `$output` at all? Usage: `$output = Assert::command($command, $exitCode = 0);`</del>


<del>3) Normalize output EOL? The `system()` keeps EOL as is, but it can be done by `exec($cmd, $out)` and `$output = implode("\n", $out)`</del>


4) Allow `$command` be an array? When array, escapeshell() every item?

Stderr issue. Ordinary exec function does not return a stderr. The only way, afaik, is `proc_open()` but it is problematic on windows. It can be done by `Assert::command('some command 2>&1')`.
