### PR TITLE
Runner: interrupted may be set in test initiation phase

### DIFF
--- a/Tester/Runner/Runner.php
+++ b/Tester/Runner/Runner.php
@@ -66,6 +66,8 @@ class Runner
 	 */
 	public function run()
 	{
+		$this->interrupted = FALSE;
+
 		foreach ($this->outputHandlers as $handler) {
 			$handler->begin();
 		}
@@ -191,8 +193,6 @@ class Runner
 	 */
 	private function installInterruptHandler()
 	{
-		$this->interrupted = FALSE;
-
 		if (extension_loaded('pcntl')) {
 			$interrupted = & $this->interrupted;
 			pcntl_signal(SIGINT, function() use (& $interrupted) {

--- a/tests/Runner.stop-on-fail.phpt
+++ b/tests/Runner.stop-on-fail.phpt
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @phpversion 5.4  Requires constant PHP_BINARY available since PHP 5.4.0
+ */
+
+use Tester\Assert,
+	Tester\Runner\Runner;
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/../Tester/Runner/OutputHandler.php';
+require __DIR__ . '/../Tester/Runner/TestHandler.php';
+require __DIR__ . '/../Tester/Runner/Runner.php';
+
+
+class Logger implements Tester\Runner\OutputHandler
+{
+	public $results = [];
+
+	function result($testName, $result, $message)
+	{
+		$this->results[] = [$result, basename($testName)];
+	}
+
+	function begin() {}
+	function end() {}
+}
+
+$interpreter = createInterpreter();
+
+
+// Normal stop on the end
+test(function() use ($interpreter) {
+	$runner = new Runner($interpreter);
+	$runner->outputHandlers[] = $logger = new Logger;
+	$runner->paths = [
+		__DIR__ . '/stop-on-fail/init-fail.phptx',
+		__DIR__ . '/stop-on-fail/runtime-fail.phptx',
+		__DIR__ . '/stop-on-fail/pass.phptx',
+	];
+
+	Assert::notSame( 0, $runner->run() );
+	Assert::same([
+		[Runner::FAILED, 'init-fail.phptx'],
+		[Runner::FAILED, 'runtime-fail.phptx'],
+		[Runner::PASSED, 'pass.phptx'],
+	], $logger->results);
+});
+
+
+// Stop in initial phase
+test(function() use ($interpreter) {
+	$runner = new Runner($interpreter);
+	$runner->outputHandlers[] = $logger = new Logger;
+	$runner->stopOnFail = TRUE;
+	$runner->paths = [
+		__DIR__ . '/stop-on-fail/init-fail.phptx',
+		__DIR__ . '/stop-on-fail/pass.phptx',
+	];
+
+	Assert::notSame( 0, $runner->run() );
+	Assert::same([
+		[Runner::FAILED, 'init-fail.phptx'],
+	], $logger->results);
+});
+
+
+// Stop in run-time
+test(function() use ($interpreter) {
+	$runner = new Runner($interpreter);
+	$runner->outputHandlers[] = $logger = new Logger;
+	$runner->stopOnFail = TRUE;
+	$runner->paths = [
+		__DIR__ . '/stop-on-fail/runtime-fail.phptx',
+		__DIR__ . '/stop-on-fail/pass.phptx',
+	];
+
+	Assert::notSame( 0, $runner->run() );
+	Assert::same([
+		[Runner::FAILED, 'runtime-fail.phptx'],
+	], $logger->results);
+});

--- a/tests/stop-on-fail/init-fail.phptx
+++ b/tests/stop-on-fail/init-fail.phptx
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * TEST: Pre-fails because does not list the TestCase methods.
+ *
+ * @testCase
+ */

--- a/tests/stop-on-fail/pass.phptx
+++ b/tests/stop-on-fail/pass.phptx
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__ . '/../bootstrap.php';
+Tester\Environment::$checkAssertions = FALSE;

--- a/tests/stop-on-fail/runtime-fail.phptx
+++ b/tests/stop-on-fail/runtime-fail.phptx
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__ . '/../bootstrap.php';
+Tester\Assert::fail('STOP');


### PR DESCRIPTION
The `Runner::$interrupted` is reseted to FALSE because it is needed in a `--watch` mode. But once per run() is enough.

I hope I didn't forget for some case, it is difficult to create a test case for this behaviour.