### PR TITLE
tests: added non-blocking Job test [WIP]

### DIFF
--- a/src/Runner/Job.php
+++ b/src/Runner/Job.php
@@ -168,6 +168,7 @@ class Job
 			return true;
 		}
 
+		$this->output = stream_get_contents($this->stdout);
 		fclose($this->stdout);
 		if ($this->stderr) {
 			fclose($this->stderr);

--- a/tests/Runner/Job.phpt
+++ b/tests/Runner/Job.phpt
@@ -29,3 +29,19 @@ test(function () {
 		Assert::contains('Nette Tester', $job->getHeaders());
 	}
 });
+
+
+test(function () {
+	$job = new Job('Job.test.phpx', createInterpreter());
+	$job->run($job::RUN_ASYNC);
+
+	usleep(10000);
+	Assert::true($job->isRunning());
+
+	while ($job->isRunning()) {
+		usleep(10000);
+	}
+
+	Assert::same(231, $job->getExitCode());
+	Assert::same('Args: ', $job->getOutput());
+});

--- a/tests/Runner/Job.test.phptx
+++ b/tests/Runner/Job.test.phptx
@@ -1,5 +1,7 @@
 <?php
 
+sleep(1);
+
 header('Love: Nette Tester');
 
 echo 'Args: ', implode(', ', array_splice($_SERVER['argv'], 1));

--- a/tests/block.phpt
+++ b/tests/block.phpt
@@ -1,0 +1,14 @@
+<?php
+
+function out($data) {
+	file_put_contents('php://stdout', $data);
+}
+
+function err($data) {
+	file_put_contents('php://stderr', $data);
+}
+
+out(str_repeat('o', 5030));
+err(str_repeat('e', 5030));
+out(str_repeat('O', 5030));
+err(str_repeat('E', 5030));


### PR DESCRIPTION
I wanted to add the test for `run(FALSE)`, but it works only in CLI mode. In CGI mode, I must call `stream_get_contents` after process is closed, it seems, that reading is blocking… Why?

The `$this->output .= stream_get_contents($this->stdout);` was added by @vrana here e641f6a9d81fef5dc9b68a8d63cf7648331005e4, but I don't know if it's really needed. 
