### PR TITLE
info.php: shorter output

### DIFF
--- a/Tester/Runner/info.php
+++ b/Tester/Runner/info.php
@@ -21,12 +21,11 @@ $values = array(
 
 	'Loaded php.ini files' => count($iniFiles) ? implode(', ', $iniFiles) : ($isHhvm ? '(unable to detect under HHVM)' : '(none)'),
 
-	$last = 'Loaded extensions' => count($extensions) ? implode(', ', $extensions) : '(none)',
+	'Loaded extensions' => count($extensions) ? implode(', ', $extensions) : '(none)',
 );
 
 foreach ($values as $title => $value) {
-	echo "\033[1;32m$title\033[0m\n";
-	echo "\033[1;37m" . str_repeat('-', strlen($title)) . "\033[0m\n";
-	echo $value . "\n";;
-	echo $title === $last ? '' : "\n\n";
+	echo "\033[1;32m$title\033[0m:\n$value\n\n";
 }
+
+echo "\n\n";


### PR DESCRIPTION
I feel that `--info` output could be more concentrated...

