### PR TITLE
Allow to acquire multiple locks

### DIFF
--- a/Tester/Framework/Environment.php
+++ b/Tester/Framework/Environment.php
@@ -136,8 +136,8 @@ class Environment
 	 */
 	public static function lock($name = '', $path = '')
 	{
-		static $lock;
-		flock($lock = fopen($path . '/lock-' . md5($name), 'w'), LOCK_EX);
+		static $locks;
+		flock($locks[] = fopen($path . '/lock-' . md5($name), 'w'), LOCK_EX);
 	}
 
 


### PR DESCRIPTION
In current implementation when Environment::lock is called multiple times only last acquired lock is saved. Previous lock are sometimes randomly garbage collected. This results in race conditions and random test failures.