### PR TITLE
Environment: acquire lock() only if not exist

### DIFF
--- a/Tester/Framework/Environment.php
+++ b/Tester/Framework/Environment.php
@@ -132,13 +132,18 @@ class Environment
 
 
 	/**
-	 * locks the parallel tests.
+	 * Locks the parallel tests.
+	 * @param  string
+	 * @param  string  lock store directory
 	 * @return void
 	 */
 	public static function lock($name = '', $path = '')
 	{
 		static $locks;
-		flock($locks[] = fopen($path . '/lock-' . md5($name), 'w'), LOCK_EX);
+		$file = "$path/lock-" . md5($name);
+		if (!isset($locks[$file])) {
+			flock($locks[$file] = fopen($file, 'w'), LOCK_EX);
+		}
 	}
 
 


### PR DESCRIPTION
Contents of static $locks exists only in one process. The acquiring can be skipped when lock already exists in this process.