### PR TITLE
Assert: equal does not use strict comparison

### DIFF
--- a/Tester/Framework/Assert.php
+++ b/Tester/Framework/Assert.php
@@ -524,7 +524,7 @@ class Assert
 			return TRUE;
 		}
 
-		return $expected === $actual;
+		return $expected == $actual;
 	}
 
 }

--- a/tests/Framework/Assert.equal.phpt
+++ b/tests/Framework/Assert.equal.phpt
@@ -27,7 +27,12 @@ $float1 = 1 / 3;
 $float2 = 1 - 2 / 3;
 
 $equals = array(
+	array(1, 1.0),
 	array(1, 1),
+	array(1, "1"),
+	array(1, TRUE),
+	array(0, FALSE),
+	array(0, NULL),
 	array('1', '1'),
 	array(array('1'), array('1')),
 	array(array('a', 'b'), array(1 => 'b', 0 => 'a')),
@@ -47,7 +52,6 @@ $equals = array(
 );
 
 $notEquals = array(
-	array(1, 1.0),
 	array(INF, -INF),
 	array(array('a', 'b'), array('b', 'a')),
 );

--- a/tests/Framework/Dumper.dumpException.phpt
+++ b/tests/Framework/Dumper.dumpException.phpt
@@ -8,7 +8,7 @@ require __DIR__ . '/../bootstrap.php';
 $cases = array(
 	"Failed: array(TRUE) should contain 1" => function() { Assert::contains(1, array(TRUE)); },
 	"Failed: array('') should not contain ''" => function() { Assert::notContains('', array('')); },
-	'Failed: 1.0 should be equal to 1' => function() { Assert::equal(1, 1.0); },
+	'Failed: 1.0 should not be equal to 1' => function() { Assert::notEqual(1, 1.0); },
 	"Failed: 0.33%d% should not be equal to 0.33%d%" => function() { Assert::notEqual(1/3, 1 - 2/3); },
 	"Failed: NULL should be FALSE" => function() { Assert::false(NULL); },
 	"Failed: FALSE should be TRUE" => function() { Assert::true(FALSE); },


### PR DESCRIPTION
I think `Assert::equal()` should not use strict comparison `===` but only weak comparison `==` should be used according to phpdoc `The identity of objects and the order of keys in the arrays are ignored.`