### PR TITLE
Added support for generating test report in JUnit XML format

### DIFF
--- a/Tester/Runner/CliTester.php
+++ b/Tester/Runner/CliTester.php
@@ -36,7 +36,7 @@ class CliTester
 		Environment::$debugMode = (bool) $this->options['--debug'];
 		if (isset($this->options['--colors'])) {
 			Environment::$useColors = (bool) $this->options['--colors'];
-		} elseif ($this->options['-o'] === 'tap') {
+		} elseif (in_array($this->options['-o'], array('tap', 'junit'))) {
 			Environment::$useColors = FALSE;
 		}
 
@@ -96,21 +96,21 @@ Usage:
     tester.php [options] [<test file> | <directory>]...
 
 Options:
-    -p <path>              Specify PHP interpreter to run (default: php-cgi).
-    -c <path>              Look for php.ini file (or look in directory) <path>.
-    -l | --log <path>      Write log to file <path>.
-    -d <key=value>...      Define INI entry 'key' with value 'val'.
-    -s                     Show information about skipped tests.
-    --stop-on-fail         Stop execution upon the first failure.
-    -j <num>               Run <num> jobs in parallel (default: 8).
-    -o <console|tap|none>  Specify output format.
-    -w | --watch <path>    Watch directory.
-    -i | --info            Show tests environment info and exit.
-    --setup <path>         Script for runner setup.
-    --colors [1|0]         Enable or disable colors.
-    --coverage <path>      Generate code coverage report to file.
-    --coverage-src <path>  Path to source code.
-    -h | --help            This help.
+    -p <path>                    Specify PHP interpreter to run (default: php-cgi).
+    -c <path>                    Look for php.ini file (or look in directory) <path>.
+    -l | --log <path>            Write log to file <path>.
+    -d <key=value>...            Define INI entry 'key' with value 'val'.
+    -s                           Show information about skipped tests.
+    --stop-on-fail               Stop execution upon the first failure.
+    -j <num>                     Run <num> jobs in parallel (default: 8).
+    -o <console|tap|junit|none>  Specify output format.
+    -w | --watch <path>          Watch directory.
+    -i | --info                  Show tests environment info and exit.
+    --setup <path>               Script for runner setup.
+    --colors [1|0]               Enable or disable colors.
+    --coverage <path>            Generate code coverage report to file.
+    --coverage-src <path>        Path to source code.
+    -h | --help                  This help.
 
 XX
 		, array(
@@ -184,9 +184,16 @@ XX
 		$runner->stopOnFail = $this->options['--stop-on-fail'];
 
 		if ($this->options['-o'] !== 'none') {
-			$runner->outputHandlers[] = $this->options['-o'] === 'tap'
-				? new Output\TapPrinter($runner)
-				: new Output\ConsolePrinter($runner, $this->options['-s']);
+			switch ($this->options['-o']) {
+				case 'tap':
+					$runner->outputHandlers[] = new Output\TapPrinter($runner);
+					break;
+				case 'junit':
+					$runner->outputHandlers[] = new Output\JUnitPrinter($runner);
+					break;
+				default:
+					$runner->outputHandlers[] = new Output\ConsolePrinter($runner, $this->options['-s']);
+			}
 		}
 
 		if ($this->options['--log']) {
@@ -222,7 +229,7 @@ XX
 	/** @return void */
 	private function finishCodeCoverage($file)
 	{
-		if ($this->options['-o'] !== 'none' && $this->options['-o'] !== 'tap') {
+		if (!in_array($this->options['-o'], array('none', 'tap', 'junit'), TRUE)) {
 			echo "Generating code coverage report\n";
 		}
 		$generator = new CodeCoverage\ReportGenerator($file, $this->options['--coverage-src']);

--- a/Tester/Runner/Output/JUnitPrinter.php
+++ b/Tester/Runner/Output/JUnitPrinter.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This file is part of the Nette Tester.
+ * Copyright (c) 2009 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Tester\Runner\Output;
+
+use Tester,
+	Tester\Runner\Runner;
+
+
+/**
+ * JUnit xml format printer.
+ */
+class JUnitPrinter implements Tester\Runner\OutputHandler
+{
+	/** @var Runner */
+	private $runner;
+
+	/** @var resource */
+	private $file;
+
+	/** @var string */
+	private $buffer;
+
+	/** @var float */
+	private $startTime;
+
+	public function __construct(Runner $runner, $file = 'php://output')
+	{
+		$this->runner = $runner;
+		$this->file = fopen($file, 'w');
+	}
+
+
+	public function begin()
+	{
+		$this->startTime = microtime(TRUE);
+		fwrite($this->file, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n");
+	}
+
+
+	public function result($testName, $result, $message)
+	{
+		$this->buffer .= "\t\t<testcase classname=\"" . htmlspecialchars($testName) . "\" name=\"" . htmlspecialchars($testName) . "\"";
+
+		switch($result) {
+			case Runner::FAILED:
+				$this->buffer .= ">\n\t\t\t<failure message=\"" . htmlspecialchars($message) . "\"/>\n\t\t</testcase>\n";
+				break;
+			case Runner::SKIPPED:
+				$this->buffer .= ">\n\t\t\t<skipped/>\n\t\t</testcase>\n";
+				break;
+			case Runner::PASSED:
+				$this->buffer .= "/>\n";
+				break;
+		}
+	}
+
+
+	public function end()
+	{
+		$time = sprintf('%0.1f', microtime(TRUE) - $this->startTime);
+		$output = $this->buffer;
+		$results = $this->runner->getResults();
+		$this->buffer = "\t<testsuite errors=\"{$results[3]}\" skipped=\"{$results[2]}\" tests=\"" . array_sum($results) . "\" time=\"$time\" timestamp=\"" . date('Y-m-d\TH:i:s') . "\">\n";
+		$this->buffer .= $output;
+		$this->buffer .= "\t</testsuite>";
+
+		fwrite($this->file, $this->buffer . "\n</testsuites>\n");
+	}
+
+}

--- a/Tester/tester.php
+++ b/Tester/tester.php
@@ -17,6 +17,7 @@ require __DIR__ . '/Runner/OutputHandler.php';
 require __DIR__ . '/Runner/Output/Logger.php';
 require __DIR__ . '/Runner/Output/TapPrinter.php';
 require __DIR__ . '/Runner/Output/ConsolePrinter.php';
+require __DIR__ . '/Runner/Output/JUnitPrinter.php';
 require __DIR__ . '/Framework/Helpers.php';
 require __DIR__ . '/Framework/Environment.php';
 require __DIR__ . '/Framework/Assert.php';

--- a/readme.md
+++ b/readme.md
@@ -178,19 +178,19 @@ Usage:
     tester.php [options] [<test file> | <directory>]...
 
 Options:
-    -p <path>              Specify PHP executable to run (default: php-cgi).
-    -c <path>              Look for php.ini file (or look in directory) <path>.
-    -l | --log <path>      Write log to file <path>.
-    -d <key=value>...      Define INI entry 'key' with value 'val'.
-    -s                     Show information about skipped tests.
-    --stop-on-fail         Stop execution upon the first failure.
-    -j <num>               Run <num> jobs in parallel (default: 8).
-    -o <console|tap|none>  Specify output format.
-    -w | --watch <path>    Watch directory.
-    -i | --info            Show tests environment info and exit.
-    --setup <path>         Script for runner setup.
-    --colors [1|0]         Enable or disable colors.
-    --coverage <path>      Generate code coverage report to file.
-    --coverage-src <path>  Path to source code.
-    -h | --help            This help.
+    -p <path>                    Specify PHP executable to run (default: php-cgi).
+    -c <path>                    Look for php.ini file (or look in directory) <path>.
+    -l | --log <path>            Write log to file <path>.
+    -d <key=value>...            Define INI entry 'key' with value 'val'.
+    -s                           Show information about skipped tests.
+    --stop-on-fail               Stop execution upon the first failure.
+    -j <num>                     Run <num> jobs in parallel (default: 8).
+    -o <console|tap|junit|none>  Specify output format.
+    -w | --watch <path>          Watch directory.
+    -i | --info                  Show tests environment info and exit.
+    --setup <path>               Script for runner setup.
+    --colors [1|0]               Enable or disable colors.
+    --coverage <path>            Generate code coverage report to file.
+    --coverage-src <path>        Path to source code.
+    -h | --help                  This help.
 ```

--- a/tests/RunnerOutput/JUnitPrinter.phpt
+++ b/tests/RunnerOutput/JUnitPrinter.phpt
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @phpversion 5.4  Requires constant PHP_BINARY available since PHP 5.4.0
+ */
+
+use Tester\Assert,
+	Tester\Environment,
+	Tester\Runner\Output\JUnitPrinter;
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../../Tester/Runner/TestHandler.php';
+require __DIR__ . '/../../Tester/Runner/Runner.php';
+require __DIR__ . '/../../Tester/Runner/OutputHandler.php';
+require __DIR__ . '/../../Tester/Runner/Output/JUnitPrinter.php';
+
+
+Environment::$useColors = FALSE;
+$runner = new Tester\Runner\Runner(createInterpreter());
+$printer = new JUnitPrinter($runner);
+$runner->paths[] = __DIR__ . '/cases/*.phptx';
+$runner->outputHandlers[] = $printer;
+ob_start();
+$runner->run();
+$output = ob_get_clean();
+
+$expected = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite errors="1" skipped="1" tests="3" time="%a%" timestamp="%a%">
+		<testcase classname="RunnerOutput%ds%cases%ds%fail.phptx" name="RunnerOutput%ds%cases%ds%fail.phptx">
+			<failure message="Failed: STOP
+
+in RunnerOutput%ds%cases%ds%fail.phptx(4) Tester\Assert::fail()"/>
+		</testcase>
+		<testcase classname="RunnerOutput%ds%cases%ds%pass.phptx" name="RunnerOutput%ds%cases%ds%pass.phptx"/>
+		<testcase classname="RunnerOutput%ds%cases%ds%skip.phptx" name="RunnerOutput%ds%cases%ds%skip.phptx">
+			<skipped/>
+		</testcase>
+	</testsuite>
+</testsuites>
+XML;
+
+Assert::match($expected, $output);

--- a/tests/RunnerOutput/cases/fail.phptx
+++ b/tests/RunnerOutput/cases/fail.phptx
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__ . '/../../bootstrap.php';
+Tester\Assert::fail('STOP');

--- a/tests/RunnerOutput/cases/pass.phptx
+++ b/tests/RunnerOutput/cases/pass.phptx
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__ . '/../../bootstrap.php';
+Tester\Environment::$checkAssertions = FALSE;

--- a/tests/RunnerOutput/cases/skip.phptx
+++ b/tests/RunnerOutput/cases/skip.phptx
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__ . '/../../bootstrap.php';
+Tester\Environment::skip();


### PR DESCRIPTION
- feature
- BC break - no
- documentation - not needed

JUnit format specification: http://help.catchsoftware.com/display/ET/JUnit+Format
For example [CircleCI](https://circleci.com/) supports test reports in this format. It shows reports nicely in the GUI.

![image](https://cloud.githubusercontent.com/assets/3693578/6653566/8238ec5a-ca98-11e4-84ed-5f6924fb9fdb.png)