### PR TITLE
Fixed loading HTML5 documents with older LibXML [WIP]

### DIFF
--- a/src/Framework/DomQuery.php
+++ b/src/Framework/DomQuery.php
@@ -24,6 +24,9 @@ class DomQuery extends \SimpleXMLElement
 		}
 
 		$html = preg_replace('#<(keygen|source|track|wbr)(?=\s|>)("[^"]*"|\'[^\']*\'|[^"\'>]+)*+(?<!/)>#', '<$1$2 />', $html);
+		if (LIBXML_VERSION < 20800) {
+			$html = preg_replace('~\\<meta\\s+.*?charset=(?:"|\')(.+)(?:"|\').*?\\>~i', '<meta http-equiv="Content-Type" content="text/html; charset=$1" />', $html);
+		}
 
 		$dom = new \DOMDocument();
 		$old = libxml_use_internal_errors(TRUE);


### PR DESCRIPTION
This is more like a bugreport than solution. The regexp should be a little smarter but I don't have time to play with extreme cases right now :-(

- http://www.glenscott.co.uk/blog/html5-character-encodings-and-domdocument-loadhtml-and-loadhtmlfile/

> Unfortunately, it only looks for the HTML4 style declaration. This means that if your source document is HTML5, it will not pick up the newer meta tag declaration. It seems that this glitch has been fixed in version 2.8.0 of Libxml.

- http://phpfashion.com/php-dom-interni-poznamky

> je nutné specifikovat kódování meta hlavičkou, jinak použje  ISO-8859-1, ale vlastnost $dom->encoding nastaví na NULL a už nepůjde změnit při ukládání