### PR TITLE
Coverage: updated source code template

### DIFF
--- a/src/CodeCoverage/Generators/template.phtml
+++ b/src/CodeCoverage/Generators/template.phtml
@@ -150,27 +150,29 @@
 
 		<div class="file" id="fragment<?php echo $id ?>">
 			<div class="lines">
-				<?php
-					$source = highlight_file($info->file, TRUE);
-					$lineCount = count(explode('<br />', $source));
+				<code>
+					<?php
+						$source = highlight_file($info->file, TRUE);
+						$lineCount = count(explode('<br />', $source));
 
-					$prevColor = NULL;
-					for ($n = 1; $n < $lineCount; ++$n) {
-						if (isset($info->lines[$n]) && isset($classes[$info->lines[$n]])) {
-							$color = $classes[$info->lines[$n]];
-						} else {
-							$color = '';  // not executable
-						}
-						if (!$prevColor) {
-							$prevColor = $color;
-						}
+						$prevColor = NULL;
+						for ($n = 1; $n < $lineCount; ++$n) {
+							if (isset($info->lines[$n]) && isset($classes[$info->lines[$n]])) {
+								$color = $classes[$info->lines[$n]];
+							} else {
+								$color = '';  // not executable
+							}
+							if (!$prevColor) {
+								$prevColor = $color;
+							}
 
-						if ($color) {
-							echo "<div class=\"color $color\"></div>";
+							if ($color) {
+								echo "<div class=\"color $color\"></div>";
+							}
+							echo "$n<br />";
 						}
-						echo "$n<br />";
-					}
-				?>
+					?>
+				</code>
 			</div>
 			<div class="source">
 				<?php echo $source ?>

--- a/src/CodeCoverage/Generators/template.phtml
+++ b/src/CodeCoverage/Generators/template.phtml
@@ -67,6 +67,7 @@
 		width: 90%;
 		width: calc(100% - 83px);
 		white-space: nowrap;
+		line-height: 18px;
 	}
 
 	.clear {

--- a/src/CodeCoverage/Generators/template.phtml
+++ b/src/CodeCoverage/Generators/template.phtml
@@ -37,6 +37,9 @@
 		word-wrap: normal;
 		width: 1000px;
 		overflow: hidden;
+	    border: 1px solid #DEDEDE;
+    	border-radius: 3px;
+    	margin-bottom: 4ex;
 	}
 
 	.lines {
@@ -57,7 +60,6 @@
 		-moz-user-select: none;
 		-ms-user-select: none;
 		user-select: none;
-		padding-left: 10px;
 		padding-right: 10px
 	}
 
@@ -83,11 +85,11 @@
 	}
 
 	.t {
-		background: #E6FFE5;
+		background: #D2EFD2;
 	}
 
 	.u {
-		background: #FFECEC;
+		background: #F6D5D5;
 	}
 
 	td {
@@ -104,8 +106,7 @@
 	}
 
 	.bar {
-		border: 1px solid #ACACAC;
-		background: #e50400;
+		background: hsl(0, 71%, 55%);
 		width: 35px;
 		height: 1em;
 	}
@@ -116,7 +117,7 @@
 	}
 
 	.light td {
-		opacity: .5;
+		opacity: .6;
 	}
 
 	.light td * {
@@ -124,7 +125,12 @@
 	}
 
 	.not-loaded td * {
-		color: red;
+		color: hsl(360, 72%, 51%);
+	}
+
+	table a {
+		text-decoration: none;
+		color: hsl(240, 63%, 48%);
 	}
 	</style>
 </head>

--- a/src/CodeCoverage/Generators/template.phtml
+++ b/src/CodeCoverage/Generators/template.phtml
@@ -132,7 +132,7 @@
 	<h1><?php echo $title ? htmlSpecialChars("$title - ") : ''; ?>Code coverage <?php echo $totalSum ? round($coveredSum * 100 / $totalSum) : 0 ?>&nbsp;%</h1>
 
 	<?php foreach ($files as $id => $info): ?>
-	<table>
+	<div>
 		<table>
 		<tr<?php echo $info->class ? " class='$info->class'" : '' ?>>
 			<td class="number"><small><?php echo $info->coverage ?> %</small></td>
@@ -169,8 +169,8 @@
 				<?php highlight_file($info->file) ?>
 			</div>
 		</div>
-		<div class="clear" />
-	</table>
+		<div class="clear"></div>
+	</div>
 	<?php endforeach ?>
 
 	<footer>

--- a/src/CodeCoverage/Generators/template.phtml
+++ b/src/CodeCoverage/Generators/template.phtml
@@ -19,6 +19,7 @@
 		background: white;
 		color: #333;
 		overflow-y: scroll;
+		overflow-x: hidden;
 	}
 
 	h1 {
@@ -33,14 +34,15 @@
 		font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
 		font-size: 12px;
 		color: #333;
-		overflow: visible;
 		word-wrap: normal;
-		border-collapse: collapse;
+		width: 1000px;
+		overflow: hidden;
 	}
 
-	.line-num {
-		width: 1%;
-		min-width: 50px;
+	.lines {
+		float: left;
+
+		width: 50px;
 		white-space: nowrap;
 		font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
 		font-size: 12px;
@@ -59,8 +61,24 @@
 		padding-right: 10px
 	}
 
-	.code {
+	.source {
+		float: left;
 		padding-left: 10px;
+		width: 90%;
+		width: calc(100% - 83px);
+		white-space: nowrap;
+	}
+
+	.clear {
+		clear: both;
+	}
+
+	.color {
+		position: absolute;
+		display: block;
+		height: 18px;
+		width: 1000px;
+		z-index: -1;
 	}
 
 	.t {
@@ -123,30 +141,35 @@
 		</tr>
 		</table>
 
-		<table class="file" id="fragment<?php echo $id ?>">
-		<?php
-			$source = explode('<br />', highlight_file($info->file, TRUE));
+		<div class="file" id="fragment<?php echo $id ?>">
+			<div class="lines">
+				<?php
+					$keys = array_keys($info->lines);
+					$lines = array_pop($keys);
 
-			end($source);
-			$numWidth = strlen((string) key($source));
+					$prevColor = NULL;
+					for ($n = 1; $n < $lines; ++$n) {
+						if (isset($info->lines[$n]) && isset($classes[$info->lines[$n]])) {
+							$color = $classes[$info->lines[$n]];
+						} else {
+							$color = '';  // not executable
+						}
+						if (!$prevColor) {
+							$prevColor = $color;
+						}
 
-			unset($prevColor);
-			foreach ($source as $n => $line):
-				if (isset($info->lines[$n + 1]) && isset($classes[$info->lines[$n + 1]])) {
-					$color = $classes[$info->lines[$n + 1]];
-				} else {
-					$color = '';  // not executable
-				}
-				if (!isset($prevColor)) {
-					$prevColor = $color;
-				}
+						if ($color) {
+							echo "<div class=\"color $color\"></div>";
+						}
+						echo "$n<br />";
+					}
 				?>
-				<tr<?php echo $color ? " class=\"$color\"" : '' ?>>
-					<td class="line-num"><?php echo $n + 1 ?></td>
-					<td class="code"><?php echo $line ?></td>
-				</tr>
-			<?php endforeach ?>
-		</table>
+			</div>
+			<div class="source">
+				<?php highlight_file($info->file) ?>
+			</div>
+		</div>
+		<div class="clear" />
 	</table>
 	<?php endforeach ?>
 

--- a/src/CodeCoverage/Generators/template.phtml
+++ b/src/CodeCoverage/Generators/template.phtml
@@ -18,6 +18,7 @@
 		margin: -4.7em auto 0;
 		background: white;
 		color: #333;
+		overflow-y: scroll;
 	}
 
 	h1 {
@@ -27,27 +28,47 @@
 		text-shadow: 1px 1px 0 white;
 	}
 
-	div.code {
-		font: 14px/1.2 Consolas, monospace;
-		background: #FDF5CE;
-		padding: .4em .7em;
-		border: 1px dotted silver;
-		overflow-x: auto;
+	.file {
 		display: none;
+		font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+		font-size: 12px;
+		color: #333;
+		overflow: visible;
+		word-wrap: normal;
+		border-collapse: collapse;
 	}
 
-	span.line {
-		color: #9F9C7F;
-		font-weight: normal;
-		font-style: normal;
+	.line-num {
+		width: 1%;
+		min-width: 50px;
+		white-space: nowrap;
+		font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+		font-size: 12px;
+		line-height: 18px;
+		color: rgba(0, 0, 0, 0.3);
+		vertical-align: top;
+		text-align: right;
+		border: solid #eee;
+
+		border-width: 0 1px 0 0;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
+		padding-left: 10px;
+		padding-right: 10px
+	}
+
+	.code {
+		padding-left: 10px;
 	}
 
 	.t {
-		background: #99f999;
+		background: #E6FFE5;
 	}
 
 	.u {
-		background: #f9ac9e;
+		background: #FFECEC;
 	}
 
 	td {
@@ -93,7 +114,7 @@
 	<h1><?php echo $title ? htmlSpecialChars("$title - ") : ''; ?>Code coverage <?php echo $totalSum ? round($coveredSum * 100 / $totalSum) : 0 ?>&nbsp;%</h1>
 
 	<?php foreach ($files as $id => $info): ?>
-	<div>
+	<table>
 		<table>
 		<tr<?php echo $info->class ? " class='$info->class'" : '' ?>>
 			<td class="number"><small><?php echo $info->coverage ?> %</small></td>
@@ -102,7 +123,7 @@
 		</tr>
 		</table>
 
-		<div class="code" id="fragment<?php echo $id ?>">
+		<table class="file" id="fragment<?php echo $id ?>">
 		<?php
 			$source = explode('<br />', highlight_file($info->file, TRUE));
 
@@ -110,8 +131,7 @@
 			$numWidth = strlen((string) key($source));
 
 			unset($prevColor);
-			$tags = '';
-			foreach ($source as $n => $line) {
+			foreach ($source as $n => $line):
 				if (isset($info->lines[$n + 1]) && isset($classes[$info->lines[$n + 1]])) {
 					$color = $classes[$info->lines[$n + 1]];
 				} else {
@@ -120,29 +140,14 @@
 				if (!isset($prevColor)) {
 					$prevColor = $color;
 				}
-				$line = sprintf("<span class='line'>%{$numWidth}s:    </span>", $n + 1) . $line;
-				if ($prevColor !== $color || $n === count($source) - 1) {
-					echo '<div' . ($prevColor ? " class='$prevColor'" : '') . '>', str_replace(' />', '>', $tags);
-					$openTags = array();
-					preg_match_all('#<([^>]+)#', $tags, $matches);
-					foreach ($matches[1] as $m) {
-						if ($m[0] === '/') {
-							array_pop($openTags);
-						} elseif (substr($m, -1) !== '/') {
-							$openTags[] = $m;
-						}
-					}
-					foreach (array_reverse($openTags) as $tag) {
-						echo '</' . preg_replace('# .*#', '', $tag) . '>';
-					}
-					echo "</div>\n";
-					$tags = ($openTags ? '<' . implode('><', $openTags) . '>' : '');
-					$prevColor = $color;
-				}
-				$tags .= "$line<br />\n";
-			}
-		?></div>
-	</div>
+				?>
+				<tr<?php echo $color ? " class=\"$color\"" : '' ?>>
+					<td class="line-num"><?php echo $n + 1 ?></td>
+					<td class="code"><?php echo $line ?></td>
+				</tr>
+			<?php endforeach ?>
+		</table>
+	</table>
 	<?php endforeach ?>
 
 	<footer>

--- a/src/CodeCoverage/Generators/template.phtml
+++ b/src/CodeCoverage/Generators/template.phtml
@@ -145,11 +145,11 @@
 		<div class="file" id="fragment<?php echo $id ?>">
 			<div class="lines">
 				<?php
-					$keys = array_keys($info->lines);
-					$lines = array_pop($keys);
+					$source = highlight_file($info->file, TRUE);
+					$lineCount = count(explode('<br />', $source));
 
 					$prevColor = NULL;
-					for ($n = 1; $n < $lines; ++$n) {
+					for ($n = 1; $n < $lineCount; ++$n) {
 						if (isset($info->lines[$n]) && isset($classes[$info->lines[$n]])) {
 							$color = $classes[$info->lines[$n]];
 						} else {
@@ -167,7 +167,7 @@
 				?>
 			</div>
 			<div class="source">
-				<?php highlight_file($info->file) ?>
+				<?php echo $source ?>
 			</div>
 		</div>
 		<div class="clear"></div>


### PR DESCRIPTION
- fixes line number alignment (this was already implemented but never worked properly)
- fixes copying code should not also copy line numbers
- updated colors, font and spacing

original:
<img width="1280" alt="screen shot 2015-08-03 at 12 04 33" src="https://cloud.githubusercontent.com/assets/192200/9036268/404bcbde-39e0-11e5-973d-9eeeef2fe74d.png">

proposed:
<img width="1280" alt="screen shot 2015-08-03 at 12 03 15" src="https://cloud.githubusercontent.com/assets/192200/9036270/43b5126c-39e0-11e5-821f-f1fba84191bf.png">
