### PR TITLE
Exceptions from setUp and tearDown are not subject for @throws annotation

### DIFF
--- a/tests/Framework/TestCase.annotationThrows.phpt
+++ b/tests/Framework/TestCase.annotationThrows.phpt
@@ -43,7 +43,7 @@ class MyTest extends Tester\TestCase
 	/** @throws Exception  With message */
 	public function testThrowsBadMessage()
 	{
-		throw new Exception('Bad message');
+		throw new RuntimeException('Bad message');
 	}
 
 	/** @throws E_NOTICE */
@@ -91,6 +91,14 @@ class MyTest extends Tester\TestCase
 
 }
 
+class MyTestTearDownException extends MyTest
+{
+	public function tearDown()
+	{
+		throw new RuntimeException("Error in tearDown");
+	}
+}
+
 
 $test = new MyTest;
 $test->run('testThrows');
@@ -134,3 +142,29 @@ Assert::exception(function () use ($test) {
 Assert::exception(function () use ($test) {
 	$test->run('testNoticeBadMessage');
 }, 'Tester\AssertException', "E_NOTICE with a message matching 'With message' was expected but got 'Undefined variable: a' in testNoticeBadMessage()");
+
+
+$test = new MyTestTearDownException;
+Assert::exception(function () use ($test) {
+	$test->tearDown();
+}, 'RuntimeException');
+
+Assert::exception(function () use ($test) {
+	$test->run('testThrows');
+}, 'Tester\TestCaseException', "tearDown() phase failed in testThrows()");
+
+Assert::exception(function () use ($test) {
+	$test->run('testThrowsButDont');
+}, 'Tester\AssertException', "Exception was expected, but none was thrown in testThrowsButDont()");
+
+Assert::exception(function () use ($test) {
+	$test->run('testThrowsBadClass');
+}, 'Tester\AssertException', "MyException was expected but got Tester\\TestCaseException (tearDown() phase failed) in testThrowsBadClass()");
+
+Assert::exception(function () use ($test) {
+	$test->run('testNotice');
+}, 'Tester\TestCaseException', "tearDown() phase failed in testNotice()");
+
+Assert::exception(function () use ($test) {
+	$test->run('testNoticeMessage');
+}, 'Tester\TestCaseException', "tearDown() phase failed in testNoticeMessage()");

--- a/tests/Framework/TestCase.basic.phpt
+++ b/tests/Framework/TestCase.basic.phpt
@@ -11,13 +11,18 @@ class TestCaseTest extends Tester\TestCase
 	{
 		Assert::true(FALSE);
 	}
+
+	public function testPass()
+	{
+		Assert::true(TRUE);
+	}
 }
 
 class TestCaseTearDownException extends TestCaseTest
 {
 	public function tearDown()
 	{
-		throw new RuntimeException;
+		throw new RuntimeException("Error in tearDown");
 	}
 }
 
@@ -33,6 +38,16 @@ Assert::exception(function () use ($test) {
 	$test->tearDown();
 }, 'RuntimeException');
 
+
 Assert::exception(function () use ($test) {
 	$test->run('testAssertion');
-}, 'Tester\AssertException', 'FALSE should be TRUE in testAssertion()');
+},
+'Tester\TestCaseException',
+"tearDown() phase failed in testAssertion()");
+
+
+Assert::exception(function () use ($test) {
+	$test->run('testPass');
+},
+'Tester\TestCaseException',
+"tearDown() phase failed in testPass()");


### PR DESCRIPTION
When Exception is thrown from setUp or TearDown it was processed same as when it is thrown from test itself. Combined with @throws annotation this can lead to false positive tests. For example when exception in expected from test but was not thrown due to error byt this error in test also caused throwing od exception from tearDown it passes.

Also covers case when exception is thrown both from test and tearDown.