### PR TITLE
Coverage: add support for coversNothing and covers

### DIFF
--- a/src/CodeCoverage/Collector.php
+++ b/src/CodeCoverage/Collector.php
@@ -60,7 +60,7 @@ class Collector
 	protected static function getCoverFilters()
 	{
 		$annotations = static::getCoverAnnotations();
-		if (isset($annotations['coversNothing'])) {
+		if (isset($annotations['coversnothing'])) {
 			if (isset($annotations['covers'])) {
 				throw new \Exception('Using both @covers and @coversNothing is not supported');
 			}

--- a/src/CodeCoverage/Collector.php
+++ b/src/CodeCoverage/Collector.php
@@ -73,7 +73,7 @@ class Collector
 			return self::COVER_ALL;
 		}
 
-		$filters = [];
+		$filters = array();
 		foreach ((array) $annotations['covers'] as $name) {
 			$ref = NULL;
 			try {
@@ -129,7 +129,7 @@ class Collector
 				continue;
 			}
 
-			$refs = isset($filters[$filename]) ? $filters[$filename] : [];
+			$refs = isset($filters[$filename]) ? $filters[$filename] : array();
 			foreach ($lines as $num => $val) {
 				if ($filters === self::COVER_NOTHING || ($filters !== self::COVER_ALL && !static::isCovered($refs, $num))) {
 					$val = -1;

--- a/tests/CodeCoverage/Collector.filters.phpt
+++ b/tests/CodeCoverage/Collector.filters.phpt
@@ -93,6 +93,6 @@ Assert::throws(function() {
 }, 'Exception', "~Failed to find 'BogusClassName'~");
 
 Assert::throws(function () {
-	MockCollector::$annotations = array('covers' => 'BogusClassName', 'coversNothing' => TRUE);
+	MockCollector::$annotations = array('covers' => 'BogusClassName', 'coversnothing' => TRUE);
 	MockCollector::save();
 }, 'Exception', "~both @covers and @coversNothing~");

--- a/tests/CodeCoverage/Collector.filters.phpt
+++ b/tests/CodeCoverage/Collector.filters.phpt
@@ -48,7 +48,7 @@ function getCoverage(array $annotations, $tempFile) {
 	MockCollector::save();
 	$coverage = unserialize(file_get_contents($tempFile));
 	if (!$coverage) {
-		$coverage = [];
+		$coverage = array();
 	}
 
 	// return only coverage of CoveredClass to make tests more readable
@@ -67,32 +67,32 @@ $tempFile = tempnam(sys_get_temp_dir(), 'nette-tester-coverage-');
 $a = 16;
 $b = 18;
 
-assertCoverage([$a => -1, $b => -1], [
+assertCoverage(array($a => -1, $b => -1), array(
 	'coversNothing' => TRUE
-], $tempFile);
+), $tempFile);
 
-assertCoverage([$a => 1, $b => -1], [
+assertCoverage(array($a => 1, $b => -1), array(
 	'covers' => 'CoveredClass::a'
-], $tempFile);
+), $tempFile);
 
-assertCoverage([$a => 1, $b => -1], [
+assertCoverage(array($a => 1, $b => -1), array(
 	'covers' => 'CoveredClass::a()'
-], $tempFile);
+), $tempFile);
 
-assertCoverage([$a => 1, $b => 1], [
-	'covers' => ['CoveredClass::a', 'CoveredClass::b']
-], $tempFile);
+assertCoverage(array($a => 1, $b => 1), array(
+	'covers' => array('CoveredClass::a', 'CoveredClass::b')
+), $tempFile);
 
-assertCoverage([$a => 1, $b => 1], [
-	'covers' => ['CoveredClass']
-], $tempFile);
+assertCoverage(array($a => 1, $b => 1), array(
+	'covers' => array('CoveredClass')
+), $tempFile);
 
 Assert::throws(function() {
-	MockCollector::$annotations = ['covers' => 'BogusClassName'];
+	MockCollector::$annotations = array('covers' => 'BogusClassName');
 	MockCollector::save();
 }, 'Exception', "~Failed to find 'BogusClassName'~");
 
 Assert::throws(function () {
-	MockCollector::$annotations = ['covers' => 'BogusClassName', 'coversNothing' => TRUE];
+	MockCollector::$annotations = array('covers' => 'BogusClassName', 'coversNothing' => TRUE);
 	MockCollector::save();
 }, 'Exception', "~both @covers and @coversNothing~");

--- a/tests/CodeCoverage/Collector.filters.phpt
+++ b/tests/CodeCoverage/Collector.filters.phpt
@@ -1,0 +1,98 @@
+<?php
+
+use Tester\Assert;
+use Tester\CodeCoverage;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!extension_loaded('xdebug')) {
+	Tester\Environment::skip('Requires Xdebug extension.');
+}
+
+class CoveredClass
+{
+
+	public function a() {}
+
+	public function b() {}
+}
+
+class MockCollector extends CodeCoverage\Collector
+{
+	public static $annotations;
+
+
+	public static function start($file)
+	{
+		self::$file = fopen($file, 'a+');
+		xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+	}
+
+
+	protected static function getCoverAnnotations()
+	{
+		return self::$annotations;
+	}
+
+}
+
+function getCoverage(array $annotations, $tempFile) {
+	MockCollector::$annotations = $annotations;
+	MockCollector::start($tempFile);
+
+	$instance = new CoveredClass();
+	$instance->a();
+	$instance->b();
+
+	MockCollector::save();
+	$coverage = unserialize(file_get_contents($tempFile));
+	if (!$coverage) {
+		$coverage = [];
+	}
+
+	// return only coverage of CoveredClass to make tests more readable
+	$ref = new ReflectionClass('CoveredClass');
+	return array_filter($coverage[__FILE__], function($line) use ($ref) {
+		return $line >= $ref->getStartLine() && $line <= $ref->getEndLine();
+	}, ARRAY_FILTER_USE_KEY);
+}
+
+function assertCoverage($exp, array $annotations, $tempFile) {
+	Assert::same($exp, getCoverage($annotations, $tempFile));
+}
+
+$tempFile = tempnam(sys_get_temp_dir(), 'nette-tester-coverage-');
+
+$a = 16;
+$b = 18;
+
+assertCoverage([$a => -1, $b => -1], [
+	'coversNothing' => TRUE
+], $tempFile);
+
+assertCoverage([$a => 1, $b => -1], [
+	'covers' => 'CoveredClass::a'
+], $tempFile);
+
+assertCoverage([$a => 1, $b => -1], [
+	'covers' => 'CoveredClass::a()'
+], $tempFile);
+
+assertCoverage([$a => 1, $b => 1], [
+	'covers' => ['CoveredClass::a', 'CoveredClass::b']
+], $tempFile);
+
+assertCoverage([$a => 1, $b => 1], [
+	'covers' => ['CoveredClass']
+], $tempFile);
+
+Assert::throws(function() {
+	MockCollector::$annotations = ['covers' => 'BogusClassName'];
+	MockCollector::save();
+}, 'Exception', "~Failed to find 'BogusClassName'~");
+
+Assert::throws(function () {
+	MockCollector::$annotations = ['covers' => 'BogusClassName', 'coversNothing' => TRUE];
+	MockCollector::save();
+}, 'Exception', "~both @covers and @coversNothing~");


### PR DESCRIPTION
Closes #222, cc @JanTvrdik 

Adds support for
- `@coversNothing`
- `@covers ClassName`
- `@covers ClassName::method`, `@covers ClassName::method()`

Downsides:
- `@covers` only supports FQN

Discussion: These annotations are mostly useful when actually required for all files. There are multiple options of enforcing this:
- require either `@coversNothing` or `@covers` in each test file, which would be a huge bc break
- automatically detect cover annotations, if at least one is present, force them in all tests. Minor bc break, hard to implement.
- introduce a new flag (and maybe switch default behaviour in future releases)
