### PR TITLE
Dumper: fix php outputs not ending with newline

### DIFF
--- a/src/Framework/Dumper.php
+++ b/src/Framework/Dumper.php
@@ -326,7 +326,7 @@ class Dumper
 			$path = dirname($testFile) . DIRECTORY_SEPARATOR . $path;
 		}
 		@mkdir(dirname($path)); // @ - directory may already exist
-		file_put_contents($path, is_string($content) ? $content : self::toPhp($content));
+		file_put_contents($path, is_string($content) ? $content : (self::toPhp($content) . "\n"));
 		return $path;
 	}
 


### PR DESCRIPTION
This is somewhat irritating when using diff, as some tools warn about missing newlines, making the diff harder to read.

```php
Assert::same([], ['foo']);
```

before:
```
$ diff a b
1c1
< array()
\ No newline at end of file
---
> array('foo')
\ No newline at end of file
```
after
```
$ diff a b
1c1
< array()
---
> array('foo')
```