### PR TITLE
Coverage optimizations

### DIFF
--- a/src/CodeCoverage/Collector.php
+++ b/src/CodeCoverage/Collector.php
@@ -52,7 +52,9 @@ class Collector
 			}
 
 			$pnode = &$positive[$filename];
+			$pnode = array();
 			$nnode = &$negative[$filename];
+			$nnode = array();
 
 			foreach ($lines as $num => $val) {
 				$val > 0 ? $pnode[$num] = $val : $nnode[$num] = $val;

--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -48,7 +48,7 @@ class Environment
 		$annotations = self::getTestAnnotations();
 		self::$checkAssertions = !isset($annotations['outputmatch']) && !isset($annotations['outputmatchfile']);
 
-		if (getenv(self::COVERAGE)) {
+		if (getenv(self::COVERAGE) && !in_array('--method=' . TestCase::LIST_METHODS, $_SERVER['argv'])) {
 			CodeCoverage\Collector::start(getenv(self::COVERAGE));
 		}
 	}


### PR DESCRIPTION
- Fixed bug that caused (empty) coverage to be generated even for `--method=nette-tester-list-methods`, improving startup time for codebases with a lot of test cases
- <del>Reduced blocking time of coverage to 3 % of original.</del> (merged in https://github.com/nette/tester/commit/9b62462d832f00f881fb84857986bfb51519505f)

Collector benchmark:
```
original blocking: 74.48 ms

     new prepared: 71.04 ms
     new blocking:  2.35 ms
          new sum: 73.38 ms
```
