### PR TITLE
TestCase: do not mask setUp() and tearDown() exceptions

### DIFF
--- a/tests/Framework/TestCase.annotationThrows.setUp.tearDown.phpt
+++ b/tests/Framework/TestCase.annotationThrows.setUp.tearDown.phpt
@@ -1,0 +1,96 @@
+<?php
+
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class SuccessTestCase extends TestCase
+{
+	/** @throws Exception  SuccessTestCase::testMe */
+	public function testMe()
+	{
+		throw new Exception(__METHOD__);
+	}
+}
+
+$test = new SuccessTestCase;
+$test->run();
+
+
+
+class FailingTestCase extends TestCase
+{
+	/** @throws RuntimeException  Wrong message */
+	public function testMe()
+	{
+		throw new Exception(__METHOD__);
+	}
+}
+
+Assert::exception(function () {
+	$test = new FailingTestCase;
+	$test->run();
+}, 'Tester\AssertException', 'RuntimeException was expected but got Exception (FailingTestCase::testMe) in testMe()');
+
+
+
+class SuccessButSetUpFails extends SuccessTestCase
+{
+	public function setUp()
+	{
+		throw new Exception(__METHOD__);
+	}
+}
+
+Assert::exception(function () {
+	$test = new SuccessButSetUpFails;
+	$test->run();
+}, 'Exception', 'SuccessButSetUpFails::setUp');
+
+
+
+class SuccessButTearDownFails extends SuccessTestCase
+{
+	public function tearDown()
+	{
+		throw new Exception(__METHOD__);
+	}
+}
+
+Assert::exception(function () {
+	$test = new SuccessButTearDownFails;
+	$test->run();
+}, 'Exception', 'SuccessButTearDownFails::tearDown');
+
+
+
+class FailingAndSetUpFails extends FailingTestCase
+{
+	public function setUp()
+	{
+		throw new Exception(__METHOD__);
+	}
+}
+
+Assert::exception(function () {
+	$test = new FailingAndSetUpFails;
+	$test->run();
+}, 'Exception', 'FailingAndSetUpFails::setUp');
+
+
+
+class FailingAndTearDownFails extends FailingTestCase
+{
+	public function tearDown()
+	{
+		throw new Exception(__METHOD__);
+	}
+}
+
+// tearDown() exception is never thrown when @throws assertion fails
+Assert::exception(function () {
+	$test = new FailingAndTearDownFails;
+	$test->run();
+}, 'Tester\AssertException', 'RuntimeException was expected but got Exception (FailingTestCase::testMe) in testMe()');


### PR DESCRIPTION
Currently, when test method is annotated by `@throws` and test method throws an expected exception, the `runTest()` always [escapes by throwing it](https://github.com/nette/tester/blob/fc6d85565097528168ebd9f106744a22d8155ad1/src/Framework/TestCase.php#L136) (or it can be thrown by `setUp()`) and exception from `tearDown()` is never thrown. It can be AssertException and it is buggy to mute it.

Ref #238 