### PR TITLE
AbstractGenerator: Introduced exception when no coverage data generated

### DIFF
--- a/src/CodeCoverage/Generators/AbstractGenerator.php
+++ b/src/CodeCoverage/Generators/AbstractGenerator.php
@@ -37,8 +37,11 @@ abstract class AbstractGenerator
 		if (!is_file($file)) {
 			throw new \Exception("File '$file' is missing.");
 		}
-
-		$this->data = @unserialize(file_get_contents($file)); // @ is escalated to exception
+		$coverageData = file_get_contents($file);
+		if(strlen($coverageData) === 0) {
+			throw new \Exception("There was no coverage data generated. Haven't you forget to call Tester\\Environment::setup() in your tests?");
+		}
+		$this->data = @unserialize($coverageData);
 		if (!is_array($this->data)) {
 			throw new \Exception("Content of file '$file' is invalid.");
 		}

--- a/tests/CodeCoverage/AbstractGenerator.emptyCoverage.phpt
+++ b/tests/CodeCoverage/AbstractGenerator.emptyCoverage.phpt
@@ -1,0 +1,20 @@
+<?php
+
+use Tester\CodeCoverage;
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../../src/CodeCoverage/Generators/AbstractGenerator.php';
+
+
+class FakeGenerator extends CodeCoverage\Generators\AbstractGenerator {
+
+	protected function renderSelf() {
+		throw new \Exception("Not implemented");
+	}
+}
+
+$coverageData = Tester\FileMock::create(""); // empty file
+
+\Tester\Assert::exception(function() use ($coverageData) {
+	new FakeGenerator($coverageData);
+}, "Exception", "There was no coverage data generated. Haven't you forget to call Tester\\Environment::setup() in your tests?");


### PR DESCRIPTION
Introduced exception when one forget to call \Tester\Environment::setup() in tests and running tester with coverage support.

New exception provides hint how to fix the problem.
