### PR TITLE
HtmlGenerator: Not loaded source files was not counted to coverage

### DIFF
--- a/src/CodeCoverage/Generators/HtmlGenerator.php
+++ b/src/CodeCoverage/Generators/HtmlGenerator.php
@@ -96,6 +96,8 @@ class HtmlGenerator extends AbstractGenerator
 				$coverage = round($covered * 100 / $total);
 				$this->totalSum += $total;
 				$this->coveredSum += $covered;
+			} else {
+				$this->totalSum += count(file($entry, FILE_SKIP_EMPTY_LINES));
 			}
 
 			$light = $total ? $total < 5 : count(file($entry)) < 50;


### PR DESCRIPTION
Source files that was not loaded when executing tests was not counted to coverage. This produces false results.

I've added estimator of executable lines. What do you think about this prototype? I'm not sure about duplicating code between CloverXMLGenerator and HtmlGenerator. PhpParser can provide quite accurate data for estimate of lines that can be estimated.