### PR TITLE
CliTester: explicit html_errors=off

### DIFF
--- a/src/Runner/CliTester.php
+++ b/src/Runner/CliTester.php
@@ -149,6 +149,10 @@ XX
 			echo "Note: No php.ini is used.\n";
 		}
 
+		if (in_array($this->options['-o'], array('tap', 'junit'))) {
+			$args .= ' -d html_errors=off';
+		}
+
 		foreach ($this->options['-d'] as $item) {
 			$args .= ' -d ' . Helpers::escapeArg($item);
 		}


### PR DESCRIPTION
It still can be overriden by `-d`.

The `html_output` is not useful in console output too I guess. But it would be always displayed in console like `PHP 5.6.13-0+deb8u1 | php-cgi -d html_errors=off | 8 threads`.