### PR TITLE
CI AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+build: off
+platform:
+    - x86
+    - x64
+cache:
+    - c:\php -> appveyor.yml
+    - '%LOCALAPPDATA%\Composer\files -> appveyor.yml'
+clone_folder: c:\projects\nette-tester
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+
+install:
+    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+    - IF %PHP%==1 cd c:\php
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/php-5.6.14-Win32-VC11-x86.zip
+    - IF %PHP%==1 7z x php-5.6.14-Win32-VC11-x86.zip -y >nul
+    - IF %PHP%==1 echo memory_limit=-1 >> php.ini
+    - IF %PHP%==1 echo max_execution_time=1200 >> php.ini
+    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+    - IF %PHP%==1 echo extension_dir=ext >> php.ini
+    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 del /Q *.zip
+    - IF %PHP%==1 cd ..
+    - cd c:\projects\nette-tester
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - php composer.phar install --prefer-dist --no-interaction --no-progress --ansi
+
+test_script:
+    - php src\tester.php tests -s --colors 0


### PR DESCRIPTION
This PR adds a config file for AppVeyor which is a CI similar to travis, except they run the builds on Windows machines. Therefore any possible incompatibilites can be easily discovered.

Example output https://ci.appveyor.com/project/mhujer/tester/build/1.0.5/job/sbjsu5kddnfxgiby

See https://github.com/dg/texy/pull/38 for more details.

Known issue: I wasn't able to run [the failing test](https://github.com/nette/tester/blob/b0f312e7ab9a70bbd5c92568e2a20dd46be9a529/.travis.yml#L28) and invert its return code.