### PR TITLE
CI AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,76 @@
+build: off
+cache:
+    - c:\php -> appveyor.yml
+    - '%LOCALAPPDATA%\Composer\files -> appveyor.yml'
+
+clone_folder: c:\projects\tester
+
+init:
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+
+install:
+    # Install PHP 5.3
+    - IF EXIST c:\php\53 (SET PHP=0) ELSE (mkdir c:\php\53)
+    - IF %PHP%==1 cd c:\php\53
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.3.29-Win32-VC9-x86.zip
+    - IF %PHP%==1 7z x php-5.3.29-Win32-VC9-x86.zip >nul
+    - IF %PHP%==1 del /Q *.zip
+
+    # Install PHP 5.4
+    - IF EXIST c:\php\54 (SET PHP=0) ELSE (mkdir c:\php\54)
+    - IF %PHP%==1 cd c:\php\54
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.4.44-Win32-VC9-x86.zip
+    - IF %PHP%==1 7z x php-5.4.44-Win32-VC9-x86.zip >nul
+    - IF %PHP%==1 del /Q *.zip
+
+    # Install PHP 5.5
+    - IF EXIST c:\php\55 (SET PHP=0) ELSE (mkdir c:\php\55)
+    - IF %PHP%==1 cd c:\php\55
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.5.32-Win32-VC11-x86.zip
+    - IF %PHP%==1 7z x php-5.5.32-Win32-VC11-x86.zip >nul
+    - IF %PHP%==1 del /Q *.zip
+
+    # Install PHP 5.6
+    - IF EXIST c:\php\56 (SET PHP=0) ELSE (mkdir c:\php\56)
+    - IF %PHP%==1 cd c:\php\56
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.6.18-Win32-VC11-x86.zip
+    - IF %PHP%==1 7z x php-5.6.18-Win32-VC11-x86.zip >nul
+    - IF %PHP%==1 del /Q *.zip
+
+    # Install PHP 7.0
+    - IF EXIST c:\php\70 (SET PHP=0) ELSE (mkdir c:\php\70)
+    - IF %PHP%==1 cd c:\php\70
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.0.3-Win32-VC14-x86.zip
+    - IF %PHP%==1 7z x php-7.0.3-Win32-VC14-x86.zip >nul
+    - IF %PHP%==1 del /Q *.zip
+
+    # Install PHP 7.0 x64
+    - IF EXIST c:\php\70x64 (SET PHP=0) ELSE (mkdir c:\php\70x64)
+    - IF %PHP%==1 cd c:\php\70x64
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.0.3-Win32-VC14-x64.zip
+    - IF %PHP%==1 7z x php-7.0.3-Win32-VC14-x64.zip >nul
+    - IF %PHP%==1 del /Q *.zip
+
+    - cd c:\projects\tester
+
+test_script:
+    - c:\php\53\php src\tester tests -s -p c:\php\53\php
+    - c:\php\53\php src\tester tests -s -p c:\php\53\php-cgi
+
+    - c:\php\54\php src\tester tests -s -p c:\php\54\php
+    - c:\php\54\php src\tester tests -s -p c:\php\54\php-cgi
+
+    - c:\php\55\php src\tester tests -s -p c:\php\55\php
+    - c:\php\55\php src\tester tests -s -p c:\php\55\php-cgi
+
+    - c:\php\56\php src\tester tests -s -p c:\php\56\php
+    - c:\php\56\php src\tester tests -s -p c:\php\56\php-cgi
+
+    - c:\php\70\php src\tester tests -s -p c:\php\70\php
+    - c:\php\70\php src\tester tests -s -p c:\php\70\php-cgi
+    - c:\php\70\php src\tester tests -s -p c:\php\70\phpdbg
+
+    - c:\php\70x64\php src\tester tests -s -p c:\php\70x64\php
+    - c:\php\70x64\php src\tester tests -s -p c:\php\70x64\php-cgi
+    - c:\php\70x64\php src\tester tests -s -p c:\php\70x64\phpdbg

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 
 [![Downloads this Month](https://img.shields.io/packagist/dm/nette/tester.svg)](https://packagist.org/packages/nette/tester)
 [![Build Status](https://travis-ci.org/nette/tester.svg?branch=master)](https://travis-ci.org/nette/tester)
+[![Build Status Windows](https://ci.appveyor.com/api/projects/status/github/nette/tester?branch=master&svg=true)](https://ci.appveyor.com/project/dg/tester/branch/master)
 [![Latest Stable Version](https://poser.pugx.org/nette/tester/v/stable)](https://github.com/nette/tester/releases)
 [![License](https://img.shields.io/badge/license-New%20BSD-blue.svg)](https://github.com/nette/tester/blob/master/license.md)
 

--- a/src/Framework/Dumper.php
+++ b/src/Framework/Dumper.php
@@ -368,7 +368,8 @@ class Dumper
 			NULL => '0',
 		);
 		$c = explode('/', $color);
-		return "\033[" . $colors[$c[0]] . (empty($c[1]) ? '' : ';4' . substr($colors[$c[1]], -1))
+		return "\033["
+			. str_replace(';', "m\033[", $colors[$c[0]] . (empty($c[1]) ? '' : ';4' . substr($colors[$c[1]], -1)))
 			. 'm' . $s . ($s === NULL ? '' : "\033[0m");
 	}
 

--- a/tests/Framework/Dumper.color.phpt
+++ b/tests/Framework/Dumper.color.phpt
@@ -7,11 +7,11 @@ require __DIR__ . '/../bootstrap.php';
 
 
 Assert::match("\x1b[0m", Dumper::color(NULL));
-Assert::match("\x1b[1;31m", Dumper::color('red'));
-Assert::match("\x1b[1;31;42m", Dumper::color('red/green'));
-Assert::match("\x1b[1;31;42m", Dumper::color('red/lime'));
+Assert::match("\x1b[1m\x1b[31m", Dumper::color('red'));
+Assert::match("\x1b[1m\x1b[31m\x1b[42m", Dumper::color('red/green'));
+Assert::match("\x1b[1m\x1b[31m\x1b[42m", Dumper::color('red/lime'));
 
 Assert::match("\x1b[0mhello\x1b[0m", Dumper::color(NULL, 'hello'));
-Assert::match("\x1b[1;31mhello\x1b[0m", Dumper::color('red', 'hello'));
-Assert::match("\x1b[1;31;42mhello\x1b[0m", Dumper::color('red/green', 'hello'));
-Assert::match("\x1b[1;31;42mhello\x1b[0m", Dumper::color('red/lime', 'hello'));
+Assert::match("\x1b[1m\x1b[31mhello\x1b[0m", Dumper::color('red', 'hello'));
+Assert::match("\x1b[1m\x1b[31m\x1b[42mhello\x1b[0m", Dumper::color('red/green', 'hello'));
+Assert::match("\x1b[1m\x1b[31m\x1b[42mhello\x1b[0m", Dumper::color('red/lime', 'hello'));


### PR DESCRIPTION
see #269

what is missing:
- the failing test using inverted return code (we should rely on travis)
- printing *.actual content (I'll solve when needed)
- ~~both CLI & CGI testing~~

colors fix is related to https://github.com/appveyor/ci/issues/373, but I am not sure if it should be merged