### PR TITLE
TestCase: data provider supports \Traversable

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -87,8 +87,8 @@ class TestCase
 
 			foreach ((array) $info['dataprovider'] as $provider) {
 				$res = $this->getData($provider);
-				if (!is_array($res)) {
-					throw new TestCaseException("Data provider $provider() doesn't return array.");
+				if (!is_array($res) && !$res instanceof \Traversable) {
+					throw new TestCaseException("Data provider $provider() doesn't return array or Traversable.");
 				}
 				foreach ($res as $set) {
 					$data[] = is_string(key($set)) ? array_merge($defaultParams, $set) : $set;

--- a/tests/Framework/TestCase.dataProvider.generator.phpt
+++ b/tests/Framework/TestCase.dataProvider.generator.phpt
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @phpversion 5.5
+ */
+
+use Tester\Assert;
+use Tester\Environment;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class MyTest extends Tester\TestCase
+{
+	public $order;
+
+	public function dataProvider()
+	{
+		for ($i = 0; $i < 4; $i++) {
+			yield [$i];
+		}
+	}
+
+	/** @dataProvider dataProvider */
+	public function testDataProviderGenerator($a)
+	{
+		$this->order[] = [__METHOD__, func_get_args()];
+	}
+}
+
+
+$test = new MyTest;
+$test->run('testDataProviderGenerator');
+Assert::same([
+	['MyTest::testDataProviderGenerator', [0]],
+	['MyTest::testDataProviderGenerator', [1]],
+	['MyTest::testDataProviderGenerator', [2]],
+	['MyTest::testDataProviderGenerator', [3]],
+], $test->order);

--- a/tests/Framework/TestCase.dataProvider.phpt
+++ b/tests/Framework/TestCase.dataProvider.phpt
@@ -18,7 +18,16 @@ class MyTest extends Tester\TestCase
 		);
 	}
 
-	/** @dataProvider dataProvider*/
+	public function dataProviderIterator()
+	{
+		$this->order[] = __METHOD__;
+		return new \ArrayIterator(array(
+			array(1, 2),
+			array(3, 4),
+		));
+	}
+
+	/** @dataProvider dataProvider */
 	public function testSingleDataProvider($a, $b)
 	{
 		$this->order[] = array(__METHOD__, func_get_args());
@@ -33,13 +42,19 @@ class MyTest extends Tester\TestCase
 		$this->order[] = array(__METHOD__, func_get_args());
 	}
 
+	/** @dataProvider dataProviderIterator */
+	public function testIteratorDataProvider($a, $b)
+	{
+		$this->order[] = array(__METHOD__, func_get_args());
+	}
+
 	/** @dataProvider fixtures/dataprovider.query.ini != foo */
 	public function testFileDataProvider($a = 'a', $b = 'b')
 	{
 		$this->order[] = array(__METHOD__, func_get_args());
 	}
 
-	/** @dataProvider dataProvider*/
+	/** @dataProvider dataProvider */
 	public function testAssertion()
 	{
 		Assert::true(FALSE);
@@ -65,6 +80,15 @@ Assert::same(array(
 	array('MyTest::testMultipleDataProvider', array(3, 4)),
 	array('MyTest::testMultipleDataProvider', array(1, 2)),
 	array('MyTest::testMultipleDataProvider', array(3, 4)),
+), $test->order);
+
+
+$test = new MyTest;
+$test->run('testIteratorDataProvider');
+Assert::same(array(
+	'MyTest::dataProviderIterator',
+	array('MyTest::testIteratorDataProvider', array(1, 2)),
+	array('MyTest::testIteratorDataProvider', array(3, 4)),
 ), $test->order);
 
 

--- a/tests/Framework/TestCase.invalidProvider.phpt
+++ b/tests/Framework/TestCase.invalidProvider.phpt
@@ -27,7 +27,7 @@ class InvalidProviderTest extends Tester\TestCase
 Assert::exception(function () {
 	$test = new InvalidProviderTest;
 	$test->run('testEmptyProvider');
-}, 'Tester\TestCaseException', "Data provider invalidDataProvider() doesn't return array.");
+}, 'Tester\TestCaseException', "Data provider invalidDataProvider() doesn't return array or Traversable.");
 
 Assert::exception(function () {
 	$test = new InvalidProviderTest;


### PR DESCRIPTION
I've found that if you want to return some more complex structures from a data provider or even do some other logic to it inbetween, generators seem to be a more convenient approach than arrays.

In my case, I need to test data validation of a third-party API, generating a valid request and breaking it in a lot of slightly different ways, and generators just seem to be much more expressive:

```php
public function dataProvider()
{
    $request = $this->createValidRequest();
    unset($request['title']);
    yield [$request, 'Missing parameter title'];

    $request = $this->createValidRequest();
    unset($request['description']);
    yield [$request, 'Missing parameter description'];

    // ...
}
```