### PR TITLE
Dumper: object hash

### DIFF
--- a/src/Framework/Dumper.php
+++ b/src/Framework/Dumper.php
@@ -102,7 +102,7 @@ class Dumper
 			$line .= '(' . $object->format('Y-m-d H:i:s O') . ')';
 		}
 
-		return $line . '(#' . substr(md5(spl_object_hash($object)), 0, 4) . ')';
+		return $line . '(' . self::hash($object) . ')';
 	}
 
 
@@ -114,6 +114,17 @@ class Dumper
 	public static function toPhp($var)
 	{
 		return self::_toPhp($var);
+	}
+
+
+	/**
+	 * Returns object's stripped hash.
+	 * @param  object
+	 * @return string
+	 */
+	private static function hash($object)
+	{
+		return '#' . substr(md5(spl_object_hash($object)), 0, 4);
 	}
 
 
@@ -216,9 +227,10 @@ class Dumper
 				}
 				$out .= $space;
 			}
+			$hash = self::hash($var);
 			return $class === 'stdClass'
-				? "(object) array($out)"
-				: "$class::__set_state(array($out))";
+				? "(object) /* $hash */ array($out)"
+				: "$class::__set_state(/* $hash */ array($out))";
 
 		} elseif (is_resource($var)) {
 			return '/* resource ' . get_resource_type($var) . ' */';

--- a/tests/Framework/Dumper.toPhp.phpt
+++ b/tests/Framework/Dumper.toPhp.phpt
@@ -38,12 +38,12 @@ Assert::match('array(
 )', Dumper::toPhp(array(1, 'hello', "\r" => array(), array(1, 2), array(1 => 1, 2, 3, 4, 5, 6, 7))));
 
 Assert::match('/* resource stream */', Dumper::toPhp(fopen(__FILE__, 'r')));
-Assert::match('(object) array()', Dumper::toPhp((object) NULL));
-Assert::match("(object) array(
+Assert::match('(object) /* #%a% */ array()', Dumper::toPhp((object) NULL));
+Assert::match("(object) /* #%a% */ array(
 	'a' => 'b',
 )", Dumper::toPhp((object) array('a' => 'b')));
 
-Assert::match("Test::__set_state(array(
+Assert::match("Test::__set_state(/* #%a% */ array(
 	'x' => array(10, NULL),
 	'y' => 'hello',
 	'z' => 30.0,

--- a/tests/Framework/Dumper.toPhp.recursion.phpt
+++ b/tests/Framework/Dumper.toPhp.recursion.phpt
@@ -18,7 +18,7 @@ Assert::match('array(
 
 $obj = (object) array('x' => 1, 'y' => 2);
 $obj->z = & $obj;
-Assert::match("(object) array(
+Assert::match("(object) /* #%a% */ array(
 	'x' => 1,
 	'y' => 2,
 	'z' => /* stdClass dumped on line 1 */,
@@ -39,12 +39,12 @@ Assert::match("array(
 		3,
 		array(1, 2, 3, /* Nesting level too deep or recursive dependency */),
 	),
-	(object) array(),
-	(object) array(
+	(object) /* #%a% */ array(),
+	(object) /* #%a% */ array(
 		'x' => 1,
 		'y' => 2,
 		'z' => /* stdClass dumped on line 9 */,
 	),
-	(object) array(),
+	(object) /* #%a% */ array(),
 	/* stdClass dumped on line 9 */,
 )", Dumper::toPhp($var));


### PR DESCRIPTION
If `Assert:same()` is used to compare two similiar-looking objects and the assert fails, the Tester generates two outputs which shows no difference at all.

This PR prints object's hash to distinguish the objects.