### PR TITLE
"-n" option ignores custom configuration

### DIFF
--- a/src/Runner/Job.php
+++ b/src/Runner/Job.php
@@ -83,7 +83,7 @@ class Job
 		putenv(Environment::COLORS . '=' . (int) Environment::$useColors);
 		$this->proc = proc_open(
 			$this->interpreter->getCommandLine()
-			. ' -n -d register_argc_argv=on ' . \Tester\Helpers::escapeArg($this->file) . ' ' . implode(' ', $this->args),
+			. ' -d register_argc_argv=on ' . \Tester\Helpers::escapeArg($this->file) . ' ' . implode(' ', $this->args),
 			array(
 				array('pipe', 'r'),
 				array('pipe', 'w'),


### PR DESCRIPTION
Assume that getCommandLine() returns "/usr/bin/php -c /etc/php5/cli/php.ini". Adding " -n" option to end of string silently ignores "-c" setting (I was unable to load json extension originaly). I dont know if i am missing something but its working for me, also hhvm has no -n option apparently...