### PR TITLE
TestCase: possibility of named sets in dataprovider

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -98,8 +98,13 @@ class TestCase
 				if (!is_array($res) && !$res instanceof \Traversable) {
 					throw new TestCaseException("Data provider $provider() doesn't return array or Traversable.");
 				}
-				foreach ($res as $set) {
-					$data[] = is_string(key($set)) ? array_merge($defaultParams, $set) : $set;
+				foreach ($res as $setName => $set) {
+					$set = is_string(key($set)) ? array_merge($defaultParams, $set) : $set;
+					if (is_string($setName)) {
+						$data[$setName] = $set;
+					} else {
+						$data[] = $set;
+					}
 				}
 			}
 
@@ -126,7 +131,7 @@ class TestCase
 		}
 
 
-		foreach ($data as $params) {
+		foreach ($data as $setName => $params) {
 			try {
 				$this->setUp();
 
@@ -152,7 +157,7 @@ class TestCase
 				$this->tearDown();
 
 			} catch (AssertException $e) {
-				throw $e->setMessage("$e->origMessage in {$method->getName()}(" . (substr(Dumper::toLine($params), 1, -1)) . ')');
+				throw $e->setMessage("$e->origMessage in " . (is_string($setName) ? "\"" . $setName . "\": " : "") . "{$method->getName()}(" . (substr(Dumper::toLine($params), 1, -1)) . ')');
 			}
 		}
 	}

--- a/tests/Framework/TestCase.dataProvider.phpt
+++ b/tests/Framework/TestCase.dataProvider.phpt
@@ -18,6 +18,14 @@ class MyTest extends Tester\TestCase
 		];
 	}
 
+	public function dataProviderNamedSets()
+	{
+		$this->order[] = __METHOD__;
+		return array(
+			'Test 1 and 2' => array(1, 2),
+		);
+	}
+
 	public function dataProviderIterator()
 	{
 		$this->order[] = __METHOD__;
@@ -42,6 +50,12 @@ class MyTest extends Tester\TestCase
 		$this->order[] = [__METHOD__, func_get_args()];
 	}
 
+	/** @dataProvider dataProviderNamedSets */
+	public function testDataProviderNamedSets($a, $b)
+	{
+		$this->order[] = array(__METHOD__, func_get_args());
+	}
+
 	/** @dataProvider dataProviderIterator */
 	public function testIteratorDataProvider($a, $b)
 	{
@@ -58,6 +72,12 @@ class MyTest extends Tester\TestCase
 	public function testAssertion()
 	{
 		Assert::true(FALSE);
+	}
+
+	/** @dataProvider dataProviderNamedSets */
+	public function testAssertionNamedSets()
+	{
+		Assert::true(false);
 	}
 }
 
@@ -84,6 +104,14 @@ Assert::same([
 
 
 $test = new MyTest;
+$test->runTest('testDataProviderNamedSets');
+Assert::same(array(
+	'MyTest::dataProviderNamedSets',
+	array('MyTest::testDataProviderNamedSets', array(1, 2)),
+), $test->order);
+
+
+$test = new MyTest;
 $test->runTest('testIteratorDataProvider');
 Assert::same([
 	'MyTest::dataProviderIterator',
@@ -104,3 +132,9 @@ Assert::exception(function () {
 	$test = new MyTest;
 	$test->runTest('testAssertion');
 }, 'Tester\AssertException', 'FALSE should be TRUE in testAssertion(1, 2)');
+
+
+Assert::exception(function () {
+	$test = new MyTest;
+	$test->runTest('testAssertionNamedSets');
+}, 'Tester\AssertException', 'FALSE should be TRUE in "Test 1 and 2": testAssertionNamedSets(1, 2)');

--- a/tests/Framework/TestCase.dataProvider.phpt
+++ b/tests/Framework/TestCase.dataProvider.phpt
@@ -21,9 +21,9 @@ class MyTest extends Tester\TestCase
 	public function dataProviderNamedSets()
 	{
 		$this->order[] = __METHOD__;
-		return array(
-			'Test 1 and 2' => array(1, 2),
-		);
+		return [
+			'Test 1 and 2' => [1, 2],
+		];
 	}
 
 	public function dataProviderIterator()
@@ -53,7 +53,7 @@ class MyTest extends Tester\TestCase
 	/** @dataProvider dataProviderNamedSets */
 	public function testDataProviderNamedSets($a, $b)
 	{
-		$this->order[] = array(__METHOD__, func_get_args());
+		$this->order[] = [__METHOD__, func_get_args()];
 	}
 
 	/** @dataProvider dataProviderIterator */
@@ -105,10 +105,10 @@ Assert::same([
 
 $test = new MyTest;
 $test->runTest('testDataProviderNamedSets');
-Assert::same(array(
+Assert::same([
 	'MyTest::dataProviderNamedSets',
-	array('MyTest::testDataProviderNamedSets', array(1, 2)),
-), $test->order);
+	['MyTest::testDataProviderNamedSets', [1, 2]],
+], $test->order);
 
 
 $test = new MyTest;

--- a/tests/Framework/TestCase.dataProvider.phpt
+++ b/tests/Framework/TestCase.dataProvider.phpt
@@ -77,7 +77,7 @@ class MyTest extends Tester\TestCase
 	/** @dataProvider dataProviderNamedSets */
 	public function testAssertionNamedSets()
 	{
-		Assert::true(false);
+		Assert::true(FALSE);
 	}
 }
 


### PR DESCRIPTION
Minor features which brings easier distinguishing which data the test is failing for. Useful for larger and more complicated datasets at the input.
