### PR TITLE
Pass "thread" number to test

### DIFF
--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -16,11 +16,14 @@ class Environment
 	/** Should Tester use console colors? */
 	const COLORS = 'NETTE_TESTER_COLORS';
 
-	/** Test is runned by Runner */
+	/** Test is run by Runner */
 	const RUNNER = 'NETTE_TESTER_RUNNER';
 
 	/** Code coverage file */
 	const COVERAGE = 'NETTE_TESTER_COVERAGE';
+
+	/** Thread number when run tests in multi threads */
+	const THREAD = 'NETTE_TESTER_THREAD';
 
 	/** @var bool  used for debugging Tester itself */
 	public static $debugMode = TRUE;

--- a/src/Runner/Job.php
+++ b/src/Runner/Job.php
@@ -77,6 +77,27 @@ class Job
 
 
 	/**
+	 * @param  string
+	 * @param  string
+	 * @return void
+	 */
+	public function setEnvironmentVariable($name, $value)
+	{
+		$this->envVars[$name] = $value;
+	}
+
+
+	/**
+	 * @param  string
+	 * @return string
+	 */
+	public function getEnvironmentVariable($name)
+	{
+		return $this->envVars[$name];
+	}
+
+
+	/**
 	 * Runs single test.
 	 * @param  int RUN_ASYNC | RUN_COLLECT_ERRORS
 	 * @return void

--- a/tests/Runner/Runner.environment.phpt
+++ b/tests/Runner/Runner.environment.phpt
@@ -6,3 +6,4 @@ use Tester\Environment;
 require __DIR__ . '/../bootstrap.php';
 
 Assert::same('1', getenv(Environment::RUNNER));
+Assert::match('%d%', getenv(Environment::THREAD));


### PR DESCRIPTION
Solves #301. Not sure about:
- thread terminology - maybe introduce naming `queue`, `job queue`? Something better?
- `Job::getEnvironmentVariable()` - seems that Runner should not depend on it