### PR TITLE
Collector: fix save method on strict types

### DIFF
--- a/src/CodeCoverage/Collector.php
+++ b/src/CodeCoverage/Collector.php
@@ -66,6 +66,10 @@ class Collector
 	 */
 	public static function save()
 	{
+		if (!self::isStarted()) {
+			return;
+		}
+
 		list($positive, $negative) = call_user_func([__CLASS__, self::$collector]);
 
 		flock(self::$file, LOCK_EX);


### PR DESCRIPTION
Calling `Collector::save()` without Tester coverage enabled triggers
strict types warning, which is caught by tester environment and stops
test execution. This fix halts `save()` method before the callback is
checked.

Exception is intentionally not thrown as `save()` handling would be overly complex in user created files.