### PR TITLE
Job: optimize output reader

### DIFF
--- a/src/Runner/Job.php
+++ b/src/Runner/Job.php
@@ -156,14 +156,15 @@ class Job
 		if (!is_resource($this->stdout)) {
 			return FALSE;
 		}
-		$this->output .= stream_get_contents($this->stdout);
-		if ($this->stderr) {
-			$this->errorOutput .= stream_get_contents($this->stderr);
-		}
 
 		$status = proc_get_status($this->proc);
 		if ($status['running']) {
 			return TRUE;
+		}
+
+		$this->output = stream_get_contents($this->stdout);
+		if ($this->stderr) {
+			$this->errorOutput = stream_get_contents($this->stderr);
 		}
 
 		fclose($this->stdout);


### PR DESCRIPTION
Replaced periodic buffer access with single read per job.

Memory usage dropped by 6% (from 0.932 MB to 0.875 MB on my
code base), probably because PHP now only allocates the
strings once and does not have to move them to larger empty
memory when concatenating.

Tested on macOS. I'm not sure why it was implemented with concatenation in the first place, so if it's a hack to make it work on Windows, obviously do not merge this.

before:
  stream_get_contents 6.7 s, 66000 calls, 17.37%
  https://blackfire.io/profiles/a23288c3-ed06-4ffe-8aba-924cb2ba79f5/graph

after:
  stream_get_contents 75.4 ms, 360 calls, <1%
  https://blackfire.io/profiles/dd71c88d-9d86-4fe7-9409-1d477d51d5ec/graph