### PR TITLE
Fixed bug for phpdbg code coverage

### DIFF
--- a/src/CodeCoverage/Generators/CloverXMLGenerator.php
+++ b/src/CodeCoverage/Generators/CloverXMLGenerator.php
@@ -78,11 +78,11 @@ class CloverXMLGenerator extends AbstractGenerator
 
 			$projectMetrics->fileCount++;
 
-			if (isset($this->data[$file])) {
-				$coverageData = $this->data[$file];
-			} else {
+			if (empty($this->data[$file])) {
 				$coverageData = NULL;
 				$this->totalSum += count(file($file, FILE_SKIP_EMPTY_LINES));
+			} else {
+				$coverageData = $this->data[$file];
 			}
 
 			// TODO: split to <package> by namespace?

--- a/src/CodeCoverage/Generators/HtmlGenerator.php
+++ b/src/CodeCoverage/Generators/HtmlGenerator.php
@@ -74,7 +74,7 @@ class HtmlGenerator extends AbstractGenerator
 			$entry = (string) $entry;
 
 			$coverage = $covered = $total = 0;
-			$loaded = isset($this->data[$entry]);
+			$loaded = !empty($this->data[$entry]);
 			$lines = [];
 			if ($loaded) {
 				$lines = $this->data[$entry];


### PR DESCRIPTION
I use php 7.0.8 with phpdbg for create coverage report.

On interface php class phpdbg create empty array to `$this->data[$entry]`, because there is no rows for computing. Crash on `Error: Division by zero`.

Maybe is better fix this problem in `AbstractGenerator::_construct()`.

Thx & sorry for my english.
