### PR TITLE
Allow @skip on test methods.

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -78,6 +78,10 @@ class TestCase
 
 		$info = Helpers::parseDocComment($method->getDocComment()) + ['dataprovider' => NULL, 'throws' => NULL];
 
+		if (isset($info['skip'])) {
+			\Tester\Environment::skip($info['skip']);
+		}
+
 		if ($info['throws'] === '') {
 			throw new TestCaseException("Missing class name in @throws annotation for {$method->getName()}().");
 		} elseif (is_array($info['throws'])) {


### PR DESCRIPTION
Right now users can only `@skip` entire file or `TestCase` class.  This patch implements a simple and consistent way to skip individual tests.

What you do is you add `@skip` annotation before the `testXYZ` method to skip it.  If the file has `@testCase` annotation then individual tests are skipped.  If it has none, the entire file is skipped (same as adding `@skip` on the class instead of method).

The assumption here is that if the test is *not* a `@testCase` skipping one test doesn't make sense as they are in some way related or dependent and represent a single "feature" which should be tested in entirety.

This fixes #179