### PR TITLE
TestCase: ensure that parents tearDown() is called

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -24,6 +24,9 @@ class TestCase
 	/** @var callable|NULL|FALSE */
 	private $prevErrorHandler = FALSE;
 
+	/** @var bool */
+	private $tearDownCalled;
+
 
 	/**
 	 * Runs the test case.
@@ -149,7 +152,11 @@ class TestCase
 				}
 				$this->handleErrors = FALSE;
 
+				$this->tearDownCalled = FALSE;
 				$this->tearDown();
+				if ($this->tearDownCalled !== TRUE) {
+					throw new TestCaseException(get_class($this) . " doesn't call parents tearDown() method.");
+				}
 
 			} catch (AssertException $e) {
 				throw $e->setMessage("$e->origMessage in {$method->getName()}(" . (substr(Dumper::toLine($params), 1, -1)) . ')');
@@ -188,6 +195,7 @@ class TestCase
 	 */
 	protected function tearDown()
 	{
+		$this->tearDownCalled = TRUE;
 	}
 
 

--- a/tests/Framework/TestCase.order.errorMuted.phpt
+++ b/tests/Framework/TestCase.order.errorMuted.phpt
@@ -26,6 +26,7 @@ class Test extends Tester\TestCase
 	protected function tearDown()
 	{
 		echo __METHOD__;
+		parent::tearDown();
 	}
 
 	protected function data()

--- a/tests/Framework/TestCase.order.phpt
+++ b/tests/Framework/TestCase.order.phpt
@@ -17,6 +17,7 @@ class SuccessTest extends Tester\TestCase
 	protected function tearDown()
 	{
 		self::$order[] = __METHOD__;
+		parent::tearDown();
 	}
 
 	public function testPublic()
@@ -56,6 +57,7 @@ class FailingTest extends Tester\TestCase
 	protected function tearDown()
 	{
 		self::$order[] = __METHOD__;
+		parent::tearDown();
 	}
 
 	public function testPublic()

--- a/tests/Framework/TestCase.tearDown.parent.phpt
+++ b/tests/Framework/TestCase.tearDown.parent.phpt
@@ -1,0 +1,22 @@
+<?php
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class Test extends Tester\TestCase
+{
+	protected function tearDown()
+	{
+	}
+
+	public function testMe()
+	{
+		Assert::true(TRUE);
+	}
+}
+
+Assert::exception(function () {
+	(new Test)->run();
+}, 'Tester\TestCaseException', "Test doesn't call parents tearDown() method.");


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? yes
- doc PR: will

Not sure it is a good idea. People use the `tearDown()` for assertions. It can be accidentally skipped by inheritance.

Or maybe add new method(s), e.g. `preAssert()`, `postAssert()`, and check it there.