### PR TITLE
Execute provided script before every test (`--bootstrap`)

### DIFF
--- a/src/Runner/CliTester.php
+++ b/src/Runner/CliTester.php
@@ -54,6 +54,11 @@ class CliTester
 			return;
 		}
 
+		if (isset($this->options['--bootstrap'])) {
+			$exportedPath = var_export($this->options['--bootstrap'], TRUE);
+			$this->interpreter->addPhpIniOption('auto_prepend_file', $exportedPath);
+		}
+
 		if ($this->options['--coverage']) {
 			$coverageFile = $this->prepareCodeCoverage();
 		}
@@ -112,7 +117,8 @@ Options:
     -o <console|tap|junit|none>  Specify output format.
     -w | --watch <path>          Watch directory.
     -i | --info                  Show tests environment info and exit.
-    --setup <path>               Script for runner setup.
+    --setup <path>               Script for test runner setup. (configure Tester)
+    --bootstrap <path>           Script executed before each test (configure test environment)
     --colors [1|0]               Enable or disable colors.
     --coverage <path>            Generate code coverage report to file.
     --coverage-src <path>        Path to source code.
@@ -123,6 +129,7 @@ XX
 			'-c' => [CommandLine::REALPATH => TRUE],
 			'--watch' => [CommandLine::REPEATABLE => TRUE, CommandLine::REALPATH => TRUE],
 			'--setup' => [CommandLine::REALPATH => TRUE],
+			'--bootstrap' => [CommandLine::REALPATH => TRUE],
 			'paths' => [CommandLine::REPEATABLE => TRUE, CommandLine::VALUE => getcwd()],
 			'--debug' => [],
 			'--coverage-src' => [CommandLine::REALPATH => TRUE],

--- a/src/Runner/PhpInterpreter.php
+++ b/src/Runner/PhpInterpreter.php
@@ -64,7 +64,7 @@ class PhpInterpreter
 		$output = stream_get_contents($pipes[1]);
 		$this->error = trim(stream_get_contents($pipes[2]));
 		if (proc_close($proc)) {
-			throw new \Exception("Unable to run $path: " . preg_replace('#[\r\n ]+#', ' ', $this->error));
+			throw new \Exception("Unable to run $path: " . preg_replace('#[\r\n ]+#', ' ', $this->error . $output));
 		}
 
 		$parts = explode("\r\n\r\n", $output, 2);


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: 

There should be some global way how to configure environment of tests. Yep I'm looking at you `Environment::setup()`. 

- `--bootstrap` script should configure only environment only in way that tests can run without it
- `Environment::setup()` is probably good candidate for bootstrap script (at least coverage setup part)
- In future this can be used to simplify running coverage / setting up custom coverage collector (which needs to be done inside test but has no value for test itself)
- In contract putting auto-loader there is **very bad idea** as tests are not standalone anymore
- I have added `stdout` to `PhpInterpreter` exception when execution error occurs; this simplifies debugging if bootstrap fails for some reason

Discussion: is `--bootstrap` sufficient name? In real it should not bootstrap test, it should bootstrap test environment for Tester. It should have (almost) no connection to test itself.