### PR TITLE
bootstrap and Environment::setup() should be idempotent

### DIFF
--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -44,6 +44,12 @@ class Environment
 	 */
 	public static function setup()
 	{
+		static $alreadySetUp = FALSE;
+		if ($alreadySetUp) {
+			return;
+		}
+		$alreadySetUp = TRUE;
+
 		self::setupErrors();
 		self::setupColors();
 		self::$obLevel = ob_get_level();

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -4,16 +4,16 @@
  * Test environment initialization.
  */
 
-require __DIR__ . '/Framework/Helpers.php';
-require __DIR__ . '/Framework/Environment.php';
-require __DIR__ . '/Framework/DataProvider.php';
-require __DIR__ . '/Framework/Assert.php';
-require __DIR__ . '/Framework/AssertException.php';
-require __DIR__ . '/Framework/Dumper.php';
-require __DIR__ . '/Framework/FileMock.php';
-require __DIR__ . '/Framework/TestCase.php';
-require __DIR__ . '/Framework/DomQuery.php';
-require __DIR__ . '/CodeCoverage/Collector.php';
-require __DIR__ . '/Runner/Job.php';
+require_once __DIR__ . '/Framework/Helpers.php';
+require_once __DIR__ . '/Framework/Environment.php';
+require_once __DIR__ . '/Framework/DataProvider.php';
+require_once __DIR__ . '/Framework/Assert.php';
+require_once __DIR__ . '/Framework/AssertException.php';
+require_once __DIR__ . '/Framework/Dumper.php';
+require_once __DIR__ . '/Framework/FileMock.php';
+require_once __DIR__ . '/Framework/TestCase.php';
+require_once __DIR__ . '/Framework/DomQuery.php';
+require_once __DIR__ . '/CodeCoverage/Collector.php';
+require_once __DIR__ . '/Runner/Job.php';
 
 Tester\Environment::setup();


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: not really needed

I could not find any reason why including bootstrap twice or calling `Environment::setup()` twice would result into error. Any arguments against?

This can help with migration to `--bootstrap` option from `bootstrap.php` files where `Environment::setup()` is usually called. (related to #355)