### PR TITLE
DomQuery: fixed multiline <script> parsing

### DIFF
--- a/src/Framework/DomQuery.php
+++ b/src/Framework/DomQuery.php
@@ -27,7 +27,7 @@ class DomQuery extends \SimpleXMLElement
 		$html = preg_replace('#<(keygen|source|track|wbr)(?=\s|>)((?:"[^"]*"|\'[^\']*\'|[^"\'>])*+)(?<!/)>#', '<$1$2 />', $html);
 
 		// fix parsing of </ inside scripts
-		$html = preg_replace_callback('#(<script(?=\s|>)(?:"[^"]*"|\'[^\']*\'|[^"\'>])*+>)(.*?)(</script>)#', function ($m) {
+		$html = preg_replace_callback('#(<script(?=\s|>)(?:"[^"]*"|\'[^\']*\'|[^"\'>])*+>)(.*?)(</script>)#s', function ($m) {
 			return $m[1] . str_replace('</', '<\/', $m[2]) . $m[3];
 		}, $html);
 

--- a/tests/Framework/DomQuery.fromHtml.phpt
+++ b/tests/Framework/DomQuery.fromHtml.phpt
@@ -25,7 +25,7 @@ $q = DomQuery::fromHtml('<audio controls><source src="horse.mp3" type="audio/mpe
 Assert::true($q->has('source'));
 
 
-$q = DomQuery::fromHtml("<script>var s = '</div>';</script> <br>  <script type='text/javascript'>var s = '</div>';</script>");
+$q = DomQuery::fromHtml("<script>\nvar s = '</div>';</script> <br>  <script type='text/javascript'>var s = '</div>';\n</script>");
 Assert::true($q->has('script'));
 Assert::true($q->has('br'));
 Assert::true($q->has('script[type]'));


### PR DESCRIPTION
- bug fix? yes #337
- new feature? no
- BC break? no
- doc PR:

Fix of DomQuery::fromHtml <script> parsing for multiline scripts. Tests adjusted accordingly.