### PR TITLE
TestCase: implemented @skip and @skipOthers for test methods

### DIFF
--- a/tests/Runner/Runner.test-case.phpt
+++ b/tests/Runner/Runner.test-case.phpt
@@ -1,0 +1,49 @@
+<?php
+
+use Tester\Assert;
+use Tester\Runner\Runner;
+use Tester\Runner\Test;
+
+require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../../src/Runner/OutputHandler.php';
+require __DIR__ . '/../../src/Runner/Test.php';
+require __DIR__ . '/../../src/Runner/TestHandler.php';
+require __DIR__ . '/../../src/Runner/Runner.php';
+
+
+class Logger implements Tester\Runner\OutputHandler
+{
+	public $results = [];
+
+	function result($testName, $result, $message)
+	{
+		$this->results[basename($testName)] = [$result, $message == '' ? $message : strtok("$message\n", "\r\n")]; // == to cover NULL and ''
+	}
+
+	function begin() {}
+	function end() {}
+}
+
+$interpreter = createInterpreter();
+$interpreter->addPhpIniOption('display_errors', 'on');
+$interpreter->addPhpIniOption('html_errors', 'off');
+
+$runner = new Runner($interpreter);
+$runner->paths[] = __DIR__ . '/test-case/*.phptx';
+$runner->outputHandlers[] = $logger = new Logger;
+$runner->run();
+
+ksort($logger->results);
+
+Assert::same([
+	'skip-failed-1.phptx' => [Test::FAILED, "Tester\\TestCaseException: Cannot use @skipOthers simultaneously with @skip on 'testSkip' method."],
+	'skip-failed-2.phptx' => [Test::FAILED, "Tester\\TestCaseException: The @skipOthers can be used only once, but found on 'testSkipOne', 'testSkipTwo' methods."],
+
+	'skip-others.phptx [method=testRun]' => [2, "Skipped due to @skipOthers on 'testSkipOthers' method."],
+	'skip-others.phptx [method=testSkipOthers]' => [1, NULL],
+	'skip-others.phptx [method=testSkip]' => [2, ''],
+
+	'skip.phptx [method=testRun]' => [Test::PASSED, NULL],
+	'skip.phptx [method=testSkipMessage]' => [Test::SKIPPED, 'Just skip me.'],
+	'skip.phptx [method=testSkip]' => [Test::SKIPPED, ''],
+], $logger->results);

--- a/tests/Runner/test-case/skip-failed-1.phptx
+++ b/tests/Runner/test-case/skip-failed-1.phptx
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @testCase
+ */
+
+require __DIR__ . '/../../bootstrap.php';
+
+Tester\Environment::$checkAssertions = FALSE;
+Tester\Environment::$useColors = FALSE;
+
+
+class MySkipTest extends Tester\TestCase
+{
+	/**
+	 * @skip
+	 * @skipOthers
+	 */
+	public function testSkip()
+	{
+	}
+}
+
+(new MySkipTest)->run();

--- a/tests/Runner/test-case/skip-failed-2.phptx
+++ b/tests/Runner/test-case/skip-failed-2.phptx
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @testCase
+ */
+
+require __DIR__ . '/../../bootstrap.php';
+
+Tester\Environment::$checkAssertions = FALSE;
+Tester\Environment::$useColors = FALSE;
+
+
+class MySkipTest extends Tester\TestCase
+{
+	/**
+	 * @skipOthers
+	 */
+	public function testSkipOne()
+	{
+	}
+
+	/**
+	 * @skipOthers
+	 */
+	public function testSkipTwo()
+	{
+	}
+}
+
+(new MySkipTest)->run();

--- a/tests/Runner/test-case/skip-others.phptx
+++ b/tests/Runner/test-case/skip-others.phptx
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @testCase
+ */
+
+require __DIR__ . '/../../bootstrap.php';
+
+Tester\Environment::$checkAssertions = FALSE;
+Tester\Environment::$useColors = FALSE;
+
+
+class MySkipTest extends Tester\TestCase
+{
+	public function testRun()
+	{
+	}
+
+	/** @skip */
+	public function testSkip()
+	{
+	}
+
+	/** @skipOthers */
+	public function testSkipOthers()
+	{
+	}
+}
+
+(new MySkipTest)->run();

--- a/tests/Runner/test-case/skip.phptx
+++ b/tests/Runner/test-case/skip.phptx
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @testCase
+ */
+
+require __DIR__ . '/../../bootstrap.php';
+
+Tester\Environment::$checkAssertions = FALSE;
+Tester\Environment::$useColors = FALSE;
+
+
+class MySkipTest extends Tester\TestCase
+{
+	public function testRun()
+	{
+	}
+
+	/** @skip */
+	public function testSkip()
+	{
+	}
+
+	/** @skip Just skip me. */
+	public function testSkipMessage()
+	{
+	}
+}
+
+(new MySkipTest)->run();


### PR DESCRIPTION
- bug fix? no (#179, #218, #342)
- new feature? yes
- BC break? no
- doc PR: will

This PR adds support for `@skip` and `@skipOthers` for TestCase test methods. When `@skip` is used, method is skipped. When `@skipOthers` is used, method is run and all other methods are skipped.

This can be implemented in two ways. From `Runner` point of view (this implementation) or from `TestCase` point of view (the test is run and skip is done in runtime by `TestCase::runTest()`).

Both ways require `@testCase` to be used. Just to prevent that one `@skip` annotation skips silently all others test methods.

I choosed the first alternative because it saves resources.

TODO: Now, when `@testCase` is not used, the `@skip` and `@skipOthers` are silently ignored. So probably `TestCase::run()` should fail to indicate, that something can be wrong.
