### PR TITLE
OutputHandler v3

### DIFF
--- a/src/Runner/CliTester.php
+++ b/src/Runner/CliTester.php
@@ -201,10 +201,10 @@ XX
 		if ($this->options['-o'] !== 'none') {
 			switch ($this->options['-o']) {
 				case 'tap':
-					$runner->outputHandlers[] = new Output\TapPrinter($runner);
+					$runner->outputHandlers[] = new Output\TapPrinter;
 					break;
 				case 'junit':
-					$runner->outputHandlers[] = new Output\JUnitPrinter($runner);
+					$runner->outputHandlers[] = new Output\JUnitPrinter;
 					break;
 				default:
 					$runner->outputHandlers[] = new Output\ConsolePrinter($runner, $this->options['-s']);

--- a/src/Runner/Output/ConsolePrinter.php
+++ b/src/Runner/Output/ConsolePrinter.php
@@ -51,20 +51,20 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 	}
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
 		$outputs = [
 			Test::PASSED => '.',
 			Test::SKIPPED => 's',
 			Test::FAILED => Dumper::color('white/red', 'F'),
 		];
-		fwrite($this->file, $outputs[$result]);
+		fwrite($this->file, $outputs[$test->getResult()]);
 
-		$message = '   ' . str_replace("\n", "\n   ", trim($message)) . "\n\n";
-		if ($result === Test::FAILED) {
-			$this->buffer .= Dumper::color('red', "-- FAILED: $testName") . "\n$message";
-		} elseif ($result === Test::SKIPPED && $this->displaySkipped) {
-			$this->buffer .= "-- Skipped: $testName\n$message";
+		$message = '   ' . str_replace("\n", "\n   ", trim($test->message)) . "\n\n";
+		if ($test->getResult() === Test::FAILED) {
+			$this->buffer .= Dumper::color('red', "-- FAILED: {$test->getSignature()}") . "\n$message";
+		} elseif ($test->getResult() === Test::SKIPPED && $this->displaySkipped) {
+			$this->buffer .= "-- Skipped: {$test->getSignature()}\n$message";
 		}
 	}
 

--- a/src/Runner/Output/ConsolePrinter.php
+++ b/src/Runner/Output/ConsolePrinter.php
@@ -51,6 +51,11 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 	}
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$outputs = [

--- a/src/Runner/Output/JUnitPrinter.php
+++ b/src/Runner/Output/JUnitPrinter.php
@@ -44,6 +44,11 @@ class JUnitPrinter implements Tester\Runner\OutputHandler
 	}
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$this->buffer .= "\t\t<testcase classname=\"" . htmlspecialchars($test->getSignature()) . '" name="' . htmlspecialchars($test->getSignature()) . '"';

--- a/src/Runner/Output/JUnitPrinter.php
+++ b/src/Runner/Output/JUnitPrinter.php
@@ -44,13 +44,13 @@ class JUnitPrinter implements Tester\Runner\OutputHandler
 	}
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
-		$this->buffer .= "\t\t<testcase classname=\"" . htmlspecialchars($testName) . '" name="' . htmlspecialchars($testName) . '"';
+		$this->buffer .= "\t\t<testcase classname=\"" . htmlspecialchars($test->getSignature()) . '" name="' . htmlspecialchars($test->getSignature()) . '"';
 
-		switch ($result) {
+		switch ($test->getResult()) {
 			case Test::FAILED:
-				$this->buffer .= ">\n\t\t\t<failure message=\"" . htmlspecialchars($message) . "\"/>\n\t\t</testcase>\n";
+				$this->buffer .= ">\n\t\t\t<failure message=\"" . htmlspecialchars($test->message) . "\"/>\n\t\t</testcase>\n";
 				break;
 			case Test::SKIPPED:
 				$this->buffer .= ">\n\t\t\t<skipped/>\n\t\t</testcase>\n";

--- a/src/Runner/Output/Logger.php
+++ b/src/Runner/Output/Logger.php
@@ -39,6 +39,11 @@ class Logger implements Tester\Runner\OutputHandler
 	}
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$message = '   ' . str_replace("\n", "\n   ", Tester\Dumper::removeColors(trim($test->message)));

--- a/src/Runner/Output/Logger.php
+++ b/src/Runner/Output/Logger.php
@@ -39,15 +39,15 @@ class Logger implements Tester\Runner\OutputHandler
 	}
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
-		$message = '   ' . str_replace("\n", "\n   ", Tester\Dumper::removeColors(trim($message)));
+		$message = '   ' . str_replace("\n", "\n   ", Tester\Dumper::removeColors(trim($test->message)));
 		$outputs = [
-			Test::PASSED => "-- OK: $testName",
-			Test::SKIPPED => "-- Skipped: $testName\n$message",
-			Test::FAILED => "-- FAILED: $testName\n$message",
+			Test::PASSED => "-- OK: {$test->getSignature()}",
+			Test::SKIPPED => "-- Skipped: {$test->getSignature()}\n$message",
+			Test::FAILED => "-- FAILED: {$test->getSignature()}\n$message",
 		];
-		fwrite($this->file, $outputs[$result] . "\n\n");
+		fwrite($this->file, $outputs[$test->getResult()] . "\n\n");
 	}
 
 

--- a/src/Runner/Output/TapPrinter.php
+++ b/src/Runner/Output/TapPrinter.php
@@ -37,15 +37,15 @@ class TapPrinter implements Tester\Runner\OutputHandler
 	}
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
-		$message = str_replace("\n", "\n# ", trim($message));
+		$message = str_replace("\n", "\n# ", trim($test->message));
 		$outputs = [
-			Test::PASSED => "ok $testName",
-			Test::SKIPPED => "ok $testName #skip $message",
-			Test::FAILED => "not ok $testName\n# $message",
+			Test::PASSED => "ok {$test->getSignature()}",
+			Test::SKIPPED => "ok {$test->getSignature()} #skip $message",
+			Test::FAILED => "not ok {$test->getSignature()}\n# $message",
 		];
-		fwrite($this->file, $outputs[$result] . "\n");
+		fwrite($this->file, $outputs[$test->getResult()] . "\n");
 	}
 
 

--- a/src/Runner/Output/TapPrinter.php
+++ b/src/Runner/Output/TapPrinter.php
@@ -8,7 +8,6 @@
 namespace Tester\Runner\Output;
 
 use Tester;
-use Tester\Runner\Runner;
 use Tester\Runner\Test;
 
 
@@ -17,22 +16,26 @@ use Tester\Runner\Test;
  */
 class TapPrinter implements Tester\Runner\OutputHandler
 {
-	/** @var Runner */
-	private $runner;
-
 	/** @var resource */
 	private $file;
 
+	/** @var array */
+	private $results;
 
-	public function __construct(Runner $runner, $file = 'php://output')
+
+	public function __construct($file = 'php://output')
 	{
-		$this->runner = $runner;
 		$this->file = fopen($file, 'w');
 	}
 
 
 	public function begin()
 	{
+		$this->results = [
+			Test::PASSED => 0,
+			Test::SKIPPED => 0,
+			Test::FAILED => 0,
+		];
 		fwrite($this->file, "TAP version 13\n");
 	}
 
@@ -44,6 +47,7 @@ class TapPrinter implements Tester\Runner\OutputHandler
 
 	public function finish(Test $test)
 	{
+		$this->results[$test->getResult()]++;
 		$message = str_replace("\n", "\n# ", trim($test->message));
 		$outputs = [
 			Test::PASSED => "ok {$test->getSignature()}",
@@ -56,6 +60,6 @@ class TapPrinter implements Tester\Runner\OutputHandler
 
 	public function end()
 	{
-		fwrite($this->file, '1..' . array_sum($this->runner->getResults()));
+		fwrite($this->file, '1..' . array_sum($this->results));
 	}
 }

--- a/src/Runner/Output/TapPrinter.php
+++ b/src/Runner/Output/TapPrinter.php
@@ -37,6 +37,11 @@ class TapPrinter implements Tester\Runner\OutputHandler
 	}
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$message = str_replace("\n", "\n# ", trim($test->message));

--- a/src/Runner/OutputHandler.php
+++ b/src/Runner/OutputHandler.php
@@ -17,6 +17,8 @@ interface OutputHandler
 {
 	function begin();
 
+	function prepare(Test $test);
+
 	function finish(Test $test);
 
 	function end();

--- a/src/Runner/OutputHandler.php
+++ b/src/Runner/OutputHandler.php
@@ -17,7 +17,7 @@ interface OutputHandler
 {
 	function begin();
 
-	function result($testName, $result, $message);
+	function finish(Test $test);
 
 	function end();
 }

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -209,6 +209,17 @@ class Runner
 
 
 	/**
+	 * @return void
+	 */
+	public function prepareTest(Test $test)
+	{
+		foreach ($this->outputHandlers as $handler) {
+			$handler->prepare(clone $test);
+		}
+	}
+
+
+	/**
 	 * Writes to output handlers.
 	 * @return void
 	 */

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -212,11 +212,11 @@ class Runner
 	 * Writes to output handlers.
 	 * @return void
 	 */
-	public function writeResult(Test $test)
+	public function finishTest(Test $test)
 	{
 		$this->results[$test->getResult()]++;
 		foreach ($this->outputHandlers as $handler) {
-			$handler->result($test->getSignature(), $test->getResult(), $test->message);
+			$handler->finish(clone $test);
 		}
 
 		if ($this->tempDir) {

--- a/src/Runner/TestHandler.php
+++ b/src/Runner/TestHandler.php
@@ -56,6 +56,7 @@ class TestHandler
 						foreach (is_array($res) ? $res : [$res] as $testVariety) {
 							/** @var Test $testVariety */
 							if ($testVariety->hasResult()) {
+								$this->runner->prepareTest($testVariety);
 								$this->runner->finishTest($testVariety);
 							} else {
 								$prepared[] = $testVariety;
@@ -68,6 +69,7 @@ class TestHandler
 		}
 
 		foreach ($tests as $test) {
+			$this->runner->prepareTest($test);
 			$this->runner->addJob(new Job($test, $php, $this->runner->getEnvironmentVariables()));
 		}
 	}

--- a/src/Runner/TestHandler.php
+++ b/src/Runner/TestHandler.php
@@ -56,7 +56,7 @@ class TestHandler
 						foreach (is_array($res) ? $res : [$res] as $testVariety) {
 							/** @var Test $testVariety */
 							if ($testVariety->hasResult()) {
-								$this->runner->writeResult($testVariety);
+								$this->runner->finishTest($testVariety);
 							} else {
 								$prepared[] = $testVariety;
 							}
@@ -92,12 +92,12 @@ class TestHandler
 			foreach ((array) $annotations[$m[1]] as $arg) {
 				/** @var Test|null $res */
 				if ($res = $this->$method($job, $arg)) {
-					$this->runner->writeResult($res);
+					$this->runner->finishTest($res);
 					return;
 				}
 			}
 		}
-		$this->runner->writeResult($test->withResult(Test::PASSED, $test->message));
+		$this->runner->finishTest($test->withResult(Test::PASSED, $test->message));
 	}
 
 

--- a/tests/Runner/Runner.annotations.phpt
+++ b/tests/Runner/Runner.annotations.phpt
@@ -15,6 +15,11 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$this->results[] = [basename($test->getFile()), $test->getResult(), $test->message];

--- a/tests/Runner/Runner.annotations.phpt
+++ b/tests/Runner/Runner.annotations.phpt
@@ -15,9 +15,9 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
-		$this->results[] = [basename($testName), $result, $message];
+		$this->results[] = [basename($test->getFile()), $test->getResult(), $test->message];
 	}
 
 

--- a/tests/Runner/Runner.edge.phpt
+++ b/tests/Runner/Runner.edge.phpt
@@ -15,9 +15,9 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
-		$this->results[basename($testName)] = [$result, $message];
+		$this->results[basename($test->getFile())] = [$test->getResult(), $test->message];
 	}
 
 

--- a/tests/Runner/Runner.edge.phpt
+++ b/tests/Runner/Runner.edge.phpt
@@ -15,6 +15,11 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$this->results[basename($test->getFile())] = [$test->getResult(), $test->message];

--- a/tests/Runner/Runner.misc.phpt
+++ b/tests/Runner/Runner.misc.phpt
@@ -15,9 +15,9 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
-		$this->results[basename($testName)] = $result;
+		$this->results[basename($test->getFile())] = $test->getResult();
 	}
 
 

--- a/tests/Runner/Runner.misc.phpt
+++ b/tests/Runner/Runner.misc.phpt
@@ -15,6 +15,11 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$this->results[basename($test->getFile())] = $test->getResult();

--- a/tests/Runner/Runner.multiple-fails.phpt
+++ b/tests/Runner/Runner.multiple-fails.phpt
@@ -17,6 +17,11 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$this->results[basename($test->getFile())] = [$test->getResult(), $test->message];

--- a/tests/Runner/Runner.multiple-fails.phpt
+++ b/tests/Runner/Runner.multiple-fails.phpt
@@ -17,9 +17,9 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
-		$this->results[basename($testName)] = [$result, $message];
+		$this->results[basename($test->getFile())] = [$test->getResult(), $test->message];
 	}
 
 

--- a/tests/Runner/Runner.stop-on-fail.phpt
+++ b/tests/Runner/Runner.stop-on-fail.phpt
@@ -50,7 +50,7 @@ test(function () use ($interpreter) {
 		__DIR__ . '/stop-on-fail/pass.phptx',
 	];
 
-	Assert::notSame(0, $runner->run());
+	Assert::false($runner->run());
 	Assert::same([
 		[Test::FAILED, 'init-fail.phptx'],
 		[Test::FAILED, 'runtime-fail.phptx'],
@@ -69,7 +69,7 @@ test(function () use ($interpreter) {
 		__DIR__ . '/stop-on-fail/pass.phptx',
 	];
 
-	Assert::notSame(0, $runner->run());
+	Assert::false($runner->run());
 	Assert::same([
 		[Test::FAILED, 'init-fail.phptx'],
 	], $logger->results);
@@ -86,7 +86,7 @@ test(function () use ($interpreter) {
 		__DIR__ . '/stop-on-fail/pass.phptx',
 	];
 
-	Assert::notSame(0, $runner->run());
+	Assert::false($runner->run());
 	Assert::same([
 		[Test::FAILED, 'runtime-fail.phptx'],
 	], $logger->results);

--- a/tests/Runner/Runner.stop-on-fail.phpt
+++ b/tests/Runner/Runner.stop-on-fail.phpt
@@ -16,9 +16,9 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
-	public function result($testName, $result, $message)
+	public function finish(Test $test)
 	{
-		$this->results[] = [$result, basename($testName)];
+		$this->results[] = [$test->getResult(), basename($test->getFile())];
 	}
 
 

--- a/tests/Runner/Runner.stop-on-fail.phpt
+++ b/tests/Runner/Runner.stop-on-fail.phpt
@@ -16,6 +16,11 @@ class Logger implements Tester\Runner\OutputHandler
 	public $results = [];
 
 
+	public function prepare(Test $test)
+	{
+	}
+
+
 	public function finish(Test $test)
 	{
 		$this->results[] = [$test->getResult(), basename($test->getFile())];

--- a/tests/RunnerOutput/OutputHandlers.phpt
+++ b/tests/RunnerOutput/OutputHandlers.phpt
@@ -25,9 +25,9 @@ $runner = new Runner(createInterpreter());
 $runner->paths[] = __DIR__ . '/cases/*.phptx';
 $runner->outputHandlers[] = new Output\ConsolePrinter($runner, false, $console = FileMock::create(''));
 $runner->outputHandlers[] = new Output\ConsolePrinter($runner, true, $consoleWithSkipped = FileMock::create(''));
-$runner->outputHandlers[] = new Output\JUnitPrinter($runner, $jUnit = FileMock::create(''));
+$runner->outputHandlers[] = new Output\JUnitPrinter($jUnit = FileMock::create(''));
 $runner->outputHandlers[] = new Output\Logger($runner, $logger = FileMock::create(''));
-$runner->outputHandlers[] = new Output\TapPrinter($runner, $tap = FileMock::create(''));
+$runner->outputHandlers[] = new Output\TapPrinter($tap = FileMock::create(''));
 $runner->run();
 
 


### PR DESCRIPTION
- bug fix? no, related to #345
- new feature? yes
- BC break? **YES**
- doc PR: will

This BC break storm can be split on:
---
**OutputHandler receives whole Test instance**
So it can reach all its properties, including stout and stderr.

**Added `OutputHandler::prepare(Test $test)`**
So it can perform some prepare actions. AFAIK it is "needed" by @jiripudil for PhpStorm plugin, right?

<del>**OutputHandler is an abstract class instead of the interface**
OutputHandler is the only one place where someone can hook the Tester. It will help to prevent BC breaks</del>

**Dropped runner's `getResults()` and `getJobCount()`**
With `OutputHandler::prepare()` is easy to count jobs and results by its own. Runner itself does not need this methods.
