### PR TITLE
 CodeCoverage: fixed HTML coverage report

### DIFF
--- a/src/CodeCoverage/Generators/HtmlGenerator.php
+++ b/src/CodeCoverage/Generators/HtmlGenerator.php
@@ -86,7 +86,9 @@ class HtmlGenerator extends AbstractGenerator
 						$covered++;
 					}
 				}
-				$coverage = round($covered * 100 / $total);
+				if ($total !== 0) {
+					$coverage = round($covered * 100 / $total);
+				}
 				$this->totalSum += $total;
 				$this->coveredSum += $covered;
 			} else {


### PR DESCRIPTION
It fixed division by zero

- bug fix? yes
- new feature? no
- BC break? no

It fixing division by zero. Example of my running was:

```
$ bin/helper test-coverage
 _____ ___  ___ _____ ___  ___
|_   _/ __)( __/_   _/ __)| _ )
  |_| \___ /___) |_| \___ |_|_\  v1.7.1

Code coverage: /app/tests/coverage/integration.html
PHP 7.1.5 | '/usr/local/bin/phpdbg' -qrrb -S cli -c '/app/tests/UnitTest/php.ini' | 8 threads

.

OK (1 test, 0.3 seconds)
Generating code coverage report

Error: Division by zero
```

It does not work only in some tests. Actualy I do not know what tests.