### PR TITLE
ConsolePrinter shows only ending file path

### DIFF
--- a/src/Runner/TestHandler.php
+++ b/src/Runner/TestHandler.php
@@ -234,8 +234,7 @@ class TestHandler
 	private function getAnnotations($file)
 	{
 		$annotations = Helpers::parseDocComment(file_get_contents($file));
-		$testName = (isset($annotations[0]) ? preg_replace('#^TEST:\s*#i', '', $annotations[0]) . ' | ' : '')
-			. implode(DIRECTORY_SEPARATOR, array_slice(explode(DIRECTORY_SEPARATOR, $file), -3));
-		return [$annotations, $testName];
+		$testTitle = isset($annotations[0]) ? preg_replace('#^TEST:\s*#i', '', $annotations[0]) : null;
+		return [$annotations, $testTitle];
 	}
 }

--- a/tests/RunnerOutput/OutputHandlers.expect.console.txt
+++ b/tests/RunnerOutput/OutputHandlers.expect.console.txt
@@ -2,21 +2,21 @@
 
 F.sF.sFsF.s
 
--- FAILED: %a%01-basic.fail.phptx
+-- FAILED: 01-basic.fail.phptx
    Multi
    line
    stdout.Failed:
 
    in %a%01-basic.fail.phptx(7) Tester\Assert::fail('');
 
--- FAILED: %a%02-title.fail.phptx
+-- FAILED: Title for output handlers | 02-title.fail.phptx
    Multi
    line
    stdout.Failed:
 
    in %a%02-title.fail.phptx(11) Tester\Assert::fail('');
 
--- FAILED: %a%03-message.fail.phptx
+-- FAILED: 03-message.fail.phptx
    Multi
    line
    stdout.Failed: Multi
@@ -25,7 +25,7 @@ F.sF.sFsF.s
 
    in %a%03-message.fail.phptx(7) Tester\Assert::fail("Multi\nline\nmessage.");
 
--- FAILED: %a%04-args.fail.phptx dataprovider=thisIsAVeryVeryVeryLongArgumentNameToTestHowOutputHandlersDealWithItsLengthInTheirOutputFormatting|%a%provider.ini
+-- FAILED: 04-args.fail.phptx dataprovider=thisIsAVeryVeryVeryLongArgumentNameToTestHowOutputHandlersDealWithItsLengthInTheirOutputFormatting|%a%provider.ini
    Multi
    line
    stdout.Failed:

--- a/tests/RunnerOutput/OutputHandlers.expect.consoleWithSkip.txt
+++ b/tests/RunnerOutput/OutputHandlers.expect.consoleWithSkip.txt
@@ -2,27 +2,27 @@
 
 F.sF.sFsF.s
 
--- FAILED: %a%01-basic.fail.phptx
+-- FAILED: %a?%01-basic.fail.phptx
    Multi
    line
    stdout.Failed:
 
    in %a%01-basic.fail.phptx(7) Tester\Assert::fail('');
 
--- Skipped: %a%01-basic.skip.phptx
+-- Skipped: %a?%01-basic.skip.phptx
 
 
--- FAILED: %a%02-title.fail.phptx
+-- FAILED: Title for output handlers | 02-title.fail.phptx
    Multi
    line
    stdout.Failed:
 
    in %a%02-title.fail.phptx(11) Tester\Assert::fail('');
 
--- Skipped: %a%02-title.skip.phptx
+-- Skipped: Title for output handlers | 02-title.skip.phptx
 
 
--- FAILED: %a%03-message.fail.phptx
+-- FAILED: 03-message.fail.phptx
    Multi
    line
    stdout.Failed: Multi
@@ -31,19 +31,19 @@ F.sF.sFsF.s
 
    in %a%03-message.fail.phptx(7) Tester\Assert::fail("Multi\nline\nmessage.");
 
--- Skipped: %a%03-message.skip.phptx
+-- Skipped: 03-message.skip.phptx
    Multi
    line
    message.
 
--- FAILED: %a%04-args.fail.phptx dataprovider=thisIsAVeryVeryVeryLongArgumentNameToTestHowOutputHandlersDealWithItsLengthInTheirOutputFormatting|%a%provider.ini
+-- FAILED: 04-args.fail.phptx dataprovider=thisIsAVeryVeryVeryLongArgumentNameToTestHowOutputHandlersDealWithItsLengthInTheirOutputFormatting|%a%provider.ini
    Multi
    line
    stdout.Failed:
 
    in %a%04-args.fail.phptx(11) Tester\Assert::fail('');
 
--- Skipped: %a%04-args.skip.phptx dataprovider=thisIsAVeryVeryVeryLongArgumentNameToTestHowOutputHandlersDealWithItsLengthInTheirOutputFormatting|%a%provider.ini
+-- Skipped: 04-args.skip.phptx dataprovider=thisIsAVeryVeryVeryLongArgumentNameToTestHowOutputHandlersDealWithItsLengthInTheirOutputFormatting|%a%provider.ini
    Multi
    line
    message.


### PR DESCRIPTION
- bug fix? no
- new feature? no
- BC break? no

Two things by this PR:
- the `Test::$title` purpose redefined, it is filled by `TEST: ...title...` only if exists, otherwise `null`
- common file path of tests is not printed when test fails or is skipped.
```
# For example: for files:
/home/milo/app/tests/Folder1/TestOne.phpt
/home/milo/app/tests/Folder2/TestOne.phpt

# Console printer now drops /home/milo/app/tests/ and outputs:
-- FAILED: Folder1/TestOne.phpt
-- FAILED: Folder2/TestOne.phpt
```

This is similar to Tester 1.x behaviour, where only last 3 parts of file path have been shown.