### PR TITLE
TestCase methods listing caching

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -45,7 +45,9 @@ class TestCase
 			if ($method === self::LIST_METHODS) {
 				Environment::$checkAssertions = false;
 				header('Content-Type: text/plain');
-				echo '[' . implode(',', $methods) . ']';
+				echo "\n";
+				echo 'TestCase:' . static::class . "\n";
+				echo 'Method:' . implode("\nMethod:", $methods) . "\n";
 				return;
 			}
 			$this->runTest($method);

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -96,6 +96,7 @@ class Runner
 		}
 
 		$this->tempDir = $path;
+		$this->testHandler->setTempDirectory($path);
 	}
 
 

--- a/tests/Runner/Runner.multiple-fails.phpt
+++ b/tests/Runner/Runner.multiple-fails.phpt
@@ -50,7 +50,7 @@ $runner->outputHandlers[] = $logger = new Logger;
 $runner->run();
 
 Assert::match(
-	"TestCase in file '%a%testcase-no-methods.phptx' does not contain test methods.",
+	"Class MyTest in file '%a%testcase-no-methods.phptx' does not contain test methods.",
 	$logger->results['testcase-no-methods.phptx'][1]
 );
 Assert::same(Test::SKIPPED, $logger->results['testcase-no-methods.phptx'][0]);


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: no needed

This PR tries to solve #369 as follows.

Output of test method listing is now in format:
```
$ php tests/Framework/Assert.equal.recursive.phpt --method=nette-tester-list-methods

TestCase:RecursionTest
Method:testSimple
Method:testMultiple
Method:testDeep
Method:testCross
Method:testThirdParty
Dependency:D:\Web\dev\nette\tester\tests\Framework\Assert.equal.recursive.phpt
Dependency:D:\Web\dev\nette\tester\src\Framework\TestCase.php
```

The `TestCase:...` line is here only for check, that `TestCase::run()` method is run.

The `Method:...` lines are test methods, formerly as `[testSimple,testMultiple,...]`.

The `Dependency:...` lines are new. It is a list of declaring files. TestCase class, all its parents and all traits. With such information the `TestHandler` can keep cache.