### PR TITLE
Skip does not kill process when not in runner

### DIFF
--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -139,8 +139,11 @@ class Environment
 	public static function skip($message = '')
 	{
 		self::$checkAssertions = false;
-		echo "\nSkipped:\n$message\n";
-		die(Runner\Job::CODE_SKIP);
+
+		if (\getenv(self::RUNNER)) {
+			echo "\nSkipped:\n$message\n";
+			die(Runner\Job::CODE_SKIP);
+		}
 	}
 
 


### PR DESCRIPTION
- bug fix? yes #379
- new feature? no
- BC break? probably not, tests pass without any change

To explain the situation where this helps:

When writing a class, you usually have another test class that holds your unit tests. You make a change in the class, quickly skip (CTRL+ALT+T) to the test class, press run (CTRL+ALT+F10) to make sure nothing got broken and move to another change.

In the current state, such workflow is impossible, because if you have a skipped test in the class, execution simply stops on that skipped test an no more test are executes, so you don't know if they are broken or not. You will note it once you run the whole suite, which is unnecessarily late. Current behavior  forces the programmer to comment-out tests rather than using SKIP, which makes SKIP an useless construct.


