### PR TITLE
DomQuery: added missing error suppression for <picture>

### DIFF
--- a/src/Framework/DomQuery.php
+++ b/src/Framework/DomQuery.php
@@ -38,7 +38,7 @@ class DomQuery extends \SimpleXMLElement
 		libxml_use_internal_errors($old);
 
 		$re = '#Tag (article|aside|audio|bdi|canvas|data|datalist|figcaption|figure|footer|header|keygen|main|mark'
-			. '|meter|nav|output|progress|rb|rp|rt|rtc|ruby|section|source|template|time|track|video|wbr) invalid#';
+			. '|meter|nav|output|picture|progress|rb|rp|rt|rtc|ruby|section|source|template|time|track|video|wbr) invalid#';
 		foreach ($errors as $error) {
 			if (!preg_match($re, $error->message)) {
 				trigger_error(__METHOD__ . ": $error->message on line $error->line.", E_USER_WARNING);


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture