### PR TITLE
Repeatable --coverage-src option

### DIFF
--- a/src/CodeCoverage/Generators/AbstractGenerator.php
+++ b/src/CodeCoverage/Generators/AbstractGenerator.php
@@ -26,8 +26,8 @@ abstract class AbstractGenerator
 	/** @var array */
 	protected $data;
 
-	/** @var string */
-	protected $source;
+	/** @var array */
+	protected $sources;
 
 	/** @var int */
 	protected $totalSum = 0;
@@ -38,9 +38,9 @@ abstract class AbstractGenerator
 
 	/**
 	 * @param  string  $file  path to coverage.dat file
-	 * @param  string  $source  path to covered source file or directory
+	 * @param  array   $sources  paths to covered source files or directories
 	 */
-	public function __construct(string $file, string $source = null)
+	public function __construct(string $file, array $sources = [])
 	{
 		if (!is_file($file)) {
 			throw new \Exception("File '$file' is missing.");
@@ -51,23 +51,18 @@ abstract class AbstractGenerator
 			throw new \Exception("Content of file '$file' is invalid.");
 		}
 
-		if (!$source) {
-			$source = key($this->data);
-			for ($i = 0; $i < strlen($source); $i++) {
-				foreach ($this->data as $s => $foo) {
-					if (!isset($s[$i]) || $source[$i] !== $s[$i]) {
-						$source = substr($source, 0, $i);
-						break 2;
-					}
+		if (!$sources) {
+			$sources = [$this->getCommonFilesPath(array_keys($this->data))];
+
+		} else {
+			foreach ($sources as $source) {
+				if (!file_exists($source)) {
+					throw new \Exception("File or directory '$source' is missing.");
 				}
 			}
-			$source = dirname($source . 'x');
-
-		} elseif (!file_exists($source)) {
-			throw new \Exception("File or directory '$source' is missing.");
 		}
 
-		$this->source = realpath($source);
+		$this->sources = array_map('realpath', $sources);
 	}
 
 
@@ -103,14 +98,35 @@ abstract class AbstractGenerator
 
 	protected function getSourceIterator(): \Iterator
 	{
-		$iterator = is_dir($this->source)
-			? new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->source))
-			: new \ArrayIterator([new \SplFileInfo($this->source)]);
+		$iterator = new \AppendIterator;
+		foreach ($this->sources as $source) {
+			$iterator->append(
+				is_dir($source)
+					? new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($source))
+					: new \ArrayIterator([new \SplFileInfo($source)])
+			);
+		}
 
 		return new \CallbackFilterIterator($iterator, function (\SplFileInfo $file): bool {
 			return $file->getBasename()[0] !== '.'  // . or .. or .gitignore
 				&& in_array($file->getExtension(), $this->acceptFiles, true);
 		});
+	}
+
+
+	protected function getCommonFilesPath(array $files): string
+	{
+		$path = reset($files);
+		for ($i = 0; $i < strlen($path); $i++) {
+			foreach ($files as $file) {
+				if (!isset($file[$i]) || $path[$i] !== $file[$i]) {
+					$path = substr($path, 0, $i);
+					break 2;
+				}
+			}
+		}
+
+		return is_dir($path) ? $path : dirname($path);
 	}
 
 

--- a/src/CodeCoverage/Generators/CloverXMLGenerator.php
+++ b/src/CodeCoverage/Generators/CloverXMLGenerator.php
@@ -33,12 +33,12 @@ class CloverXMLGenerator extends AbstractGenerator
 	];
 
 
-	public function __construct(string $file, string $source = null)
+	public function __construct(string $file, array $sources = [])
 	{
 		if (!extension_loaded('dom')) {
 			throw new \LogicException('CloverXML generator requires DOM extension to be loaded.');
 		}
-		parent::__construct($file, $source);
+		parent::__construct($file, $sources);
 	}
 
 

--- a/src/CodeCoverage/Generators/HtmlGenerator.php
+++ b/src/CodeCoverage/Generators/HtmlGenerator.php
@@ -31,11 +31,11 @@ class HtmlGenerator extends AbstractGenerator
 
 	/**
 	 * @param  string  $file  path to coverage.dat file
-	 * @param  string  $source  file/directory
+	 * @param  array   $sources  files/directories
 	 */
-	public function __construct(string $file, string $source = null, string $title = null)
+	public function __construct(string $file, array $sources = [], string $title = null)
 	{
-		parent::__construct($file, $source);
+		parent::__construct($file, $sources);
 		$this->title = $title;
 	}
 
@@ -71,6 +71,7 @@ class HtmlGenerator extends AbstractGenerator
 		}
 
 		$this->files = [];
+		$commonSourcesPath = $this->getCommonFilesPath($this->sources) . DIRECTORY_SEPARATOR;
 		foreach ($this->getSourceIterator() as $entry) {
 			$entry = (string) $entry;
 
@@ -96,7 +97,7 @@ class HtmlGenerator extends AbstractGenerator
 
 			$light = $total ? $total < 5 : count(file($entry)) < 50;
 			$this->files[] = (object) [
-				'name' => str_replace((is_dir($this->source) ? $this->source : dirname($this->source)) . DIRECTORY_SEPARATOR, '', $entry),
+				'name' => str_replace($commonSourcesPath, '', $entry),
 				'file' => $entry,
 				'lines' => $lines,
 				'coverage' => $coverage,

--- a/src/Runner/CliTester.php
+++ b/src/Runner/CliTester.php
@@ -127,7 +127,7 @@ XX
 			'--temp' => [CommandLine::REALPATH => true],
 			'paths' => [CommandLine::REPEATABLE => true, CommandLine::VALUE => getcwd()],
 			'--debug' => [],
-			'--coverage-src' => [CommandLine::REALPATH => true],
+			'--coverage-src' => [CommandLine::REALPATH => true, CommandLine::REPEATABLE => true],
 		]);
 
 		if (isset($_SERVER['argv'])) {

--- a/tests/CodeCoverage/CloverXMLGenerator.phpt
+++ b/tests/CodeCoverage/CloverXMLGenerator.phpt
@@ -21,7 +21,7 @@ $coverageData = Tester\FileMock::create(serialize([
 	)),
 ]));
 
-$generator = new CodeCoverage\Generators\CloverXMLGenerator($coverageData, $coveredDir);
+$generator = new CodeCoverage\Generators\CloverXMLGenerator($coverageData, [$coveredDir]);
 $generator->render($output = Tester\FileMock::create('', 'xml'));
 
 $dom = new DOMDocument;


### PR DESCRIPTION
- new feature
- BC break? yes

Added support for repeatable `--coverage-src` option. It is useful when you have got eg. multiple directories in root of your project which you want to generate coverage for.
