### PR TITLE
Helper::purge() protection [WIP]

### DIFF
--- a/src/Framework/Helpers.php
+++ b/src/Framework/Helpers.php
@@ -20,6 +20,9 @@ class Helpers
 	 */
 	public static function purge(string $dir): void
 	{
+		if (preg_match('#^(\w:)?[/\\\\]?$#', $dir)) {
+			throw new \InvalidArgumentException('Directory must not be an empty string or root path.');
+		}
 		if (!is_dir($dir)) {
 			mkdir($dir);
 		}


### PR DESCRIPTION
- new feature?  
- BC break? no

1) Prevents an incorrect call with an empty parameter (eg due to a typo in the code), which can lead to the whole disc being deleted

2) Disables `purge('/')` or `purge('c:/') just for sure