### PR TITLE
fix FileMutator error thrown when using scandir()

### DIFF
--- a/src/Framework/FileMutator.php
+++ b/src/Framework/FileMutator.php
@@ -43,7 +43,9 @@ class FileMutator
 
 	public function dir_opendir(string $path, int $options): bool
 	{
-		$this->handle = $this->native('opendir', $path, $this->context);
+		$this->handle = $this->context
+			? $this->native('opendir', $path, $this->context)
+			: $this->native('opendir', $path);
 		return (bool) $this->handle;
 	}
 


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: not needed

FileMutator failed on `scandir()` with

```
PHP Warning:  scandir(...): failed to open dir: "Tester\FileMutator::dir_opendir" call failed ...
Fatal error: Uncaught TypeError: opendir() expects parameter 2 to be resource, null given in .../FileMutator.php on line 214
```