### PR TITLE
Add PCOV support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "nette/tester",
 	"description": "Nette Tester: enjoyable unit testing in PHP with code coverage reporter. 🍏🍏🍎🍏",
 	"homepage": "https://tester.nette.org",
-	"keywords": ["testing", "unit", "nette", "phpunit", "code coverage", "xdebug", "phpdbg", "clover", "assertions"],
+	"keywords": ["testing", "unit", "nette", "phpunit", "code coverage", "xdebug", "phpdbg", "pcov", "clover", "assertions"],
 	"license": ["BSD-3-Clause", "GPL-2.0", "GPL-3.0"],
 	"authors": [
 		{

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ composer require nette/tester --dev
 Alternatively, you can download the [tester.phar](https://github.com/nette/tester/releases) file.
 
 Nette Tester 2.0 requires PHP 5.6 and supports PHP up to 7.3. The 2.1 version requires PHP 7.1.
-Collecting and processing code coverage information depends on Xdebug, or PHPDBG.
+Collecting and processing code coverage information depends on Xdebug, PHPDBG or PCOV.
 
 
 Writing Tests
@@ -150,7 +150,7 @@ tester -j 1
 
 How do you find code that is not yet tested? Use Code-Coverage Analysis. This feature
 requires you have installed [Xdebug](https://xdebug.org/) in `php.ini`, or you are
-using PHPDBG. This will generate nice HTML report in `coverage.html`.
+using PHPDBG or [PCOV](https://github.com/krakjoe/pcov). This will generate nice HTML report in `coverage.html`.
 
 ```
 tester . -c php.ini --coverage coverage.html --coverage-src /my/source/codes

--- a/src/Runner/CliTester.php
+++ b/src/Runner/CliTester.php
@@ -222,7 +222,7 @@ XX
 	private function prepareCodeCoverage(): string
 	{
 		if (!$this->interpreter->canMeasureCodeCoverage()) {
-			throw new \Exception("Code coverage functionality requires Xdebug extension or phpdbg SAPI (used {$this->interpreter->getCommandLine()})");
+			throw new \Exception("Code coverage functionality requires Xdebug extension, phpdbg SAPI or PCOV extension (used {$this->interpreter->getCommandLine()})");
 		}
 		file_put_contents($this->options['--coverage'], '');
 		$file = realpath($this->options['--coverage']);

--- a/src/Runner/info.php
+++ b/src/Runner/info.php
@@ -21,7 +21,7 @@ $info = (object) [
 	),
 	'extensions' => $extensions,
 	'tempDir' => sys_get_temp_dir(),
-	'canMeasureCodeCoverage' => $isPhpDbg || in_array('xdebug', $extensions, true),
+	'canMeasureCodeCoverage' => $isPhpDbg || in_array('xdebug', $extensions, true) || in_array('pcov', $extensions, true),
 ];
 
 if (isset($_SERVER['argv'][1])) {

--- a/tests/CodeCoverage/Collector.phpt
+++ b/tests/CodeCoverage/Collector.phpt
@@ -9,8 +9,8 @@ use Tester\FileMock;
 require __DIR__ . '/../bootstrap.php';
 
 
-if (!extension_loaded('xdebug') && (!defined('PHPDBG_VERSION'))) {
-	Tester\Environment::skip('Requires Xdebug or phpdbg SAPI.');
+if (!extension_loaded('xdebug') && (!defined('PHPDBG_VERSION')) && !extension_loaded('pcov')) {
+	Tester\Environment::skip('Requires Xdebug, phpdbg SAPI or PCOV extension.');
 }
 
 if (CodeCoverage\Collector::isStarted()) {

--- a/tests/Runner/PhpInterpreter.Zend.phpt
+++ b/tests/Runner/PhpInterpreter.Zend.phpt
@@ -11,5 +11,5 @@ $interpreter = createInterpreter();
 
 Assert::contains(PHP_BINARY, $interpreter->getCommandLine());
 Assert::same(PHP_VERSION, $interpreter->getVersion());
-Assert::same(extension_loaded('xdebug') || defined('PHPDBG_VERSION'), $interpreter->canMeasureCodeCoverage());
+Assert::same(extension_loaded('xdebug') || defined('PHPDBG_VERSION') || extension_loaded('pcov'), $interpreter->canMeasureCodeCoverage());
 Assert::same(strpos(PHP_SAPI, 'cgi') !== false, $interpreter->isCgi());


### PR DESCRIPTION
- new feature
- BC break? no

Hello,

I met an announcement about PHPUnit 8 support [PCOV](https://github.com/krakjoe/pcov) which should be really fast in comparison to other code coverage possibilities, e.g. https://twitter.com/kornrunner/status/1091381371447230464, https://twitter.com/RemiCollet/status/1091336903423594496, etc.

This PR adds support for it.