### PR TITLE
Assert::equal() makes the difference in order of lists (BC break)

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -572,8 +572,13 @@ class Assert
 		}
 
 		if (is_array($expected) && is_array($actual)) {
-			ksort($expected, SORT_STRING);
-			ksort($actual, SORT_STRING);
+			if ($expected && array_keys($expected) === range(0, count($expected) - 1)) {
+				reset($expected);
+				reset($actual);
+			} else {
+				ksort($expected, SORT_STRING);
+				ksort($actual, SORT_STRING);
+			}
 			if (array_keys($expected) !== array_keys($actual)) {
 				return false;
 			}

--- a/tests/Framework/Assert.equal.phpt
+++ b/tests/Framework/Assert.equal.phpt
@@ -32,7 +32,6 @@ $equals = [
 	[1, 1],
 	['1', '1'],
 	[['1'], ['1']],
-	[['a', 'b'], [1 => 'b', 0 => 'a']],
 	[['a' => true, 'b' => false], ['b' => false, 'a' => true]],
 	[new stdClass, new stdClass],
 	[[new stdClass], [new stdClass]],
@@ -50,6 +49,7 @@ $equals = [
 
 $notEquals = [
 	[1, 1.0],
+	[['a', 'b'], [1 => 'b', 0 => 'a']],
 	[INF, -INF],
 	[['a', 'b'], ['b', 'a']],
 	[NAN, NAN],


### PR DESCRIPTION
- BC break? yes

It affects only seqences indexed from. Here is the anomaly in sorting usually undesirable. So with this change these arrays are not equal anymore:

```php
['a', 'b']
[1 => 'b', 0 => 'a'] 
```

It is BC break. I would suggest merge it in the master **after** releasing the next version to see if it hasn't a negative impact.


