### PR TITLE
Prints the result of the current test

### DIFF
--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -106,11 +106,11 @@ class Environment
 				if (in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE], true)) {
 					if (($error['type'] & error_reporting()) !== $error['type']) { // show fatal errors hidden by @shutup
 						self::removeOutputBuffers();
-						echo "\nFatal error: $error[message] in $error[file] on line $error[line]\n";
+						echo "\n", Dumper::color('white/red', "Fatal error: $error[message] in $error[file] on line $error[line]"), "\n";
 					}
 				} elseif (self::$checkAssertions && !Assert::$counter) {
 					self::removeOutputBuffers();
-					echo "\nError: This test forgets to execute an assertion.\n";
+					echo "\n", Dumper::color('white/red', 'Error: This test forgets to execute an assertion.'), "\n";
 					exit(Runner\Job::CODE_FAIL);
 				}
 			});

--- a/tests/Runner/Runner.multiple-fails.phpt
+++ b/tests/Runner/Runner.multiple-fails.phpt
@@ -58,7 +58,7 @@ Assert::same(Test::SKIPPED, $logger->results['testcase-no-methods.phptx'][0]);
 
 Assert::match(
 	'Error: This test forgets to execute an assertion.',
-	trim($logger->results['testcase-not-call-run.phptx'][1])
+	trim(Dumper::removeColors($logger->results['testcase-not-call-run.phptx'][1]))
 );
 Assert::same(Test::FAILED, $logger->results['testcase-not-call-run.phptx'][0]);
 


### PR DESCRIPTION
- new feature?  
- BC break? no

It may not be clear from the blank screen is test was successful. Did it start? Didn't PHP crashed (parse error?) before Environment::setup() was called? Did I started the test at all or I see a few minutes old result in the console? (Sometimes I am tired :)