### PR TITLE
Added support for interpreter annotation

### DIFF
--- a/src/Runner/Job.php
+++ b/src/Runner/Job.php
@@ -102,9 +102,14 @@ class Job
 			}
 		}
 
+		$testFilePath = $this->test->getFile();
+        $annotations = Helpers::parseDocComment(file_get_contents($testFilePath));
+        $interpreter = $annotations['interpreter'] ?? 'php';
+        $commandLine = $this->interpreter->getCommandLine();
+
 		$this->proc = proc_open(
-			$this->interpreter->getCommandLine()
-			. ' -d register_argc_argv=on ' . Helpers::escapeArg($this->test->getFile()) . ' ' . implode(' ', $args),
+            $interpreter . substr($commandLine, strpos($commandLine, ' '))
+			. ' -d register_argc_argv=on ' . Helpers::escapeArg($testFilePath) . ' ' . implode(' ', $args),
 			[
 				['pipe', 'r'],
 				['pipe', 'w'],


### PR DESCRIPTION
- new feature
- BC break? no

It will be really nice to have an option to specify the interpreter within a test itself via an annotation. There are use cases when I want some tests in php and other in php-cgi and I didn't find out, so I wrote a simple solution. Please let me know what do you think. Thanks.