### PR TITLE
Performance assert

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ This table shows all assertions (class `Assert` means `Tester\Assert`):
 - `Assert::match($pattern, $value)` - Compares result using regular expression or mask.
 - `Assert::matchFile($file, $value)` - Compares result using regular expression or mask sorted in file.
 - `Assert::count($count, $value)` - Reports an error if number of items in $value is not $count.
+- `Assert::performance($limitMs, $closure)` - Measures the process time of the function.
 
 Testing exceptions:
 

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -315,6 +315,28 @@ class Assert
 
 
 	/**
+	 * Asserts that measures the process time of function.
+	 */
+	public static function performance(float $limitMs, callable $function, string $description = null): void
+	{
+		$startTime = microtime(true);
+		try {
+			$function();
+		} catch (\Throwable $e) {
+			self::fail($e->getMessage());
+		}
+		$processTime = (float) ((microtime(true) - $startTime) * 1000);
+		if ($processTime > $limitMs) {
+			self::fail(
+				self::describe('Function is too slow. Limit %1 expected, but real time is %2.', $description),
+				number_format($limitMs, 3, '.', '') . ' ms',
+				number_format($processTime, 3, '.', '') . ' ms'
+			);
+		}
+	}
+
+
+	/**
 	 * Asserts that a function generates one or more PHP errors or throws exceptions.
 	 * @param  int|string|array $expectedType
 	 * @param  string $expectedMessage message

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -323,7 +323,7 @@ class Assert
 		try {
 			$function();
 		} catch (\Throwable $e) {
-			self::fail($e->getMessage());
+			self::fail(self::describe($e->getMessage(), $description));
 		}
 		$processTime = (float) ((microtime(true) - $startTime) * 1000);
 		if ($processTime > $limitMs) {

--- a/tests/Framework/Assert.performance.phpt
+++ b/tests/Framework/Assert.performance.phpt
@@ -18,3 +18,10 @@ Assert::exception(function () {
 		sleep(1);
 	});
 }, Tester\AssertException::class, 'Function is too slow. Limit \'%f% ms\' expected, but real time is \'%f% ms\'.');
+
+
+Assert::exception(function () {
+	Assert::performance(500, function () {
+		throw new \Exception('Something was wrong.');
+	});
+}, Tester\AssertException::class, 'Something was wrong.');

--- a/tests/Framework/Assert.performance.phpt
+++ b/tests/Framework/Assert.performance.phpt
@@ -15,12 +15,10 @@ Assert::performance(1000, function () {
 // Negative
 $e = null;
 try {
-	Assert::performance(5, function () {
-		password_hash('password', PASSWORD_DEFAULT);
+	Assert::performance(500, function () {
+		sleep(1);
 	});
 } catch (\Tester\AssertException $e) {
 }
 
-if ($e === null) {
-	Assert::fail('Performance password function must throw exception.');
-}
+Assert::true($e === null, 'Performance password function must throw exception.');

--- a/tests/Framework/Assert.performance.phpt
+++ b/tests/Framework/Assert.performance.phpt
@@ -17,4 +17,4 @@ Assert::exception(function () {
 	Assert::performance(500, function () {
 		sleep(1);
 	});
-}, Tester\AssertException::class, 'Performance password function must throw exception.');
+}, Tester\AssertException::class, 'Function is too slow. Limit \'%f% ms\' expected, but real time is \'%f% ms\'.');

--- a/tests/Framework/Assert.performance.phpt
+++ b/tests/Framework/Assert.performance.phpt
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// Positive
+Assert::performance(1000, function () {
+	$sum = 5 + 3;
+});
+
+// Negative
+Assert::exception(function () {
+	Assert::performance(5, function () {
+		password_hash('password', PASSWORD_DEFAULT);
+	});
+}, Tester\AssertException::class, 'The function can never be evaluated.');

--- a/tests/Framework/Assert.performance.phpt
+++ b/tests/Framework/Assert.performance.phpt
@@ -13,8 +13,14 @@ Assert::performance(1000, function () {
 });
 
 // Negative
-Assert::exception(function () {
+$e = null;
+try {
 	Assert::performance(5, function () {
 		password_hash('password', PASSWORD_DEFAULT);
 	});
-}, Tester\AssertException::class, 'The function can never be evaluated.');
+} catch (\Tester\AssertException $e) {
+}
+
+if ($e === null) {
+	Assert::fail('Performance password function must throw exception.');
+}

--- a/tests/Framework/Assert.performance.phpt
+++ b/tests/Framework/Assert.performance.phpt
@@ -13,12 +13,8 @@ Assert::performance(1000, function () {
 });
 
 // Negative
-$e = null;
-try {
+Assert::exception(function () {
 	Assert::performance(500, function () {
 		sleep(1);
 	});
-} catch (\Tester\AssertException $e) {
-}
-
-Assert::true($e === null, 'Performance password function must throw exception.');
+}, Tester\AssertException::class, 'Performance password function must throw exception.');


### PR DESCRIPTION
- new feature
- BC break? no

New very useful assert `Assert::performance()` added for define maximum time limit for function execution time.

Params: `performance(float $limitMs, callable $function, string $description = null)`.

Example:

```php
Assert::performance(300, function () {
	(new Passwords)->hash('secret');
}, 'Generating must be faster than 300 ms.');
```

I think this basic assert should be included in native Tester to define boundaries before the start of development.