### PR TITLE
Environment: File can be undefined.

### DIFF
--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -166,8 +166,8 @@ class Environment
 	public static function getTestAnnotations(): array
 	{
 		$trace = debug_backtrace();
-		$file = $trace[count($trace) - 1]['file'];
-		return Helpers::parseDocComment(file_get_contents($file)) + ['file' => $file];
+		$file = $trace[count($trace) - 1]['file'] ?? null;
+		return Helpers::parseDocComment($file ? file_get_contents($file) : '') + ['file' => $file];
 	}
 
 


### PR DESCRIPTION
- bug fix
- BC break? yes

In case of Doctrine ORM Schema update when all entities are loaded automatically, `$trace` with index `file` can be undefined.

<img width="429" alt="Snímek obrazovky 2019-09-09 v 13 54 22" src="https://user-images.githubusercontent.com/4738758/64528682-6427b100-d309-11e9-96e9-2bf245e71200.png">
