### PR TITLE
Dumper: keep full data provider name in output files

### DIFF
--- a/src/Framework/Dumper.php
+++ b/src/Framework/Dumper.php
@@ -268,7 +268,7 @@ class Dumper
 				|| is_object($actual) || is_array($actual) || (is_string($actual) && strlen($actual) > self::$maxLength)
 			) {
 				$args = isset($_SERVER['argv'][1])
-					? '.[' . implode(' ', preg_replace(['#^-*(.{1,20}).*#i', '#[^=a-z0-9. -]+#i'], ['$1', '-'], array_slice($_SERVER['argv'], 1))) . ']'
+					? '.[' . implode(' ', preg_replace(['#^-*([^|]+).*#i', '#[^=a-z0-9. -]+#i'], ['$1', '-'], array_slice($_SERVER['argv'], 1))) . ']'
 					: '';
 				$stored[] = self::saveOutput($testFile, $expected, $args . '.expected');
 				$stored[] = self::saveOutput($testFile, $actual, $args . '.actual');

--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -106,7 +106,7 @@ class Environment
 
 			$error = error_get_last();
 			register_shutdown_function(function () use ($error): void {
-				if (in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE], true)) {
+				if (in_array($error['type'] ?? null, [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE], true)) {
 					if (($error['type'] & error_reporting()) !== $error['type']) { // show fatal errors hidden by @shutup
 						self::removeOutputBuffers();
 						echo "\n", Dumper::color('white/red', "Fatal error: $error[message] in $error[file] on line $error[line]"), "\n";


### PR DESCRIPTION
- new feature
- BC break? no 

I created test case `Test.phpt` with following data provider variations:
- `source_1`
- `source_2`
- `source_3`

All of them failed on assert, but only single output pair of files was produced:
```
Test.[dataprovider=source-].actual
Test.[dataprovider=source-]
```

The number got cut off due to limitations of 20 chars in `Dumper` - which this PR changes to unlimited amount until encountering `|` which seems to be used as delimiter by Tester.

Please let me know if this is reasonable improvement; from my perspective it would help in my case tremendously (`source_<n>` is supposed to be actually meaningful longer thing).