### PR TITLE
Allow SVG elements in DOM (close #354).

### DIFF
--- a/src/Framework/DomQuery.php
+++ b/src/Framework/DomQuery.php
@@ -37,7 +37,14 @@ class DomQuery extends \SimpleXMLElement
 		libxml_use_internal_errors($old);
 
 		$re = '#Tag (article|aside|audio|bdi|canvas|data|datalist|figcaption|figure|footer|header|keygen|main|mark'
-			. '|meter|nav|output|picture|progress|rb|rp|rt|rtc|ruby|section|source|template|time|track|video|wbr) invalid#';
+			. '|meter|nav|output|picture|progress|rb|rp|rt|rtc|ruby|section|source|svg|template|time|track|video|wbr'
+			. '|animate|animateMotion|animateTransform|circle|clipPath|color-profile|defs|desc|discard|ellipse|feBlend'
+			. '|feColorMatrix|feComponentTransfer|feComposite|feConvolveMatrix|feDiffuseLighting|feDisplacementMap'
+			. '|feDistantLight|feDropShadow|feFlood|feFuncA|feFuncB|feFuncG|feFuncR|feGaussianBlur|feImage|feMerge'
+			. '|feMergeNode|feMorphology|feOffset|fePointLight|feSpecularLighting|feSpotLight|feTile|feTurbulence'
+			. '|filter|foreignObject|g|hatch|hatchpath|image|line|linearGradient|marker|mask|mesh|meshgradient|meshpatch'
+			. '|meshrow|metadata|mpath|path|pattern|polygon|polyline|radialGradient|rect|script|set|solidcolor|stop|'
+			. 'style|switch|symbol|text|textPath|title|tspan|unknown|use|view) invalid#';
 		foreach ($errors as $error) {
 			if (!preg_match($re, $error->message)) {
 				trigger_error(__METHOD__ . ": $error->message on line $error->line.", E_USER_WARNING);

--- a/tests/Framework/DomQuery.fromHtmlSvg.phpt
+++ b/tests/Framework/DomQuery.fromHtmlSvg.phpt
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+use Tester\DomQuery;
+
+require __DIR__ . '/../bootstrap.php';
+
+$html = <<<'SRC'
+<html>
+	<body>hello</body>
+	<svg version="1.1" baseProfile="full" width="300" height="200" xmlns="http://www.w3.org/2000/svg">
+	    <rect width="100%" height="100%" fill="red" />
+		<circle cx="150" cy="100" r="80" fill="green" />
+		<text x="150" y="125" font-size="60" text-anchor="middle" fill="white">SVG</text>
+	</svg>
+	<svg role="img" aria-label="" title="" class="shape shape-share-fb view-head button-icon">
+		<use xlink:href="#shape-share-fb"></use>
+	</svg>
+</html>
+SRC;
+
+$q = DomQuery::fromHtml($html);
+Assert::true($q->has('body'));
+Assert::true($q->has('svg'));
+Assert::true($q->has('rect'));
+Assert::true($q->has('text'));
+Assert::true($q->has('circle'));
+Assert::true($q->has('use'));
+Assert::false($q->has('p'));


### PR DESCRIPTION
- bug fix
- BC break? no

Added `svg` to the list of supported HTML tags. Also added the rest of known SVG elements as per [MDN SVG Elements](https://developer.mozilla.org/en-US/docs/Web/SVG/Element) page.