### PR TITLE
simplexml must be required #401

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1"
+		"php": ">=7.1",
+		"ext-simplexml": "*"
 	},
 	"require-dev": {
-		"ext-simplexml": "*",
 		"phpstan/phpstan": "^0.12"
 	},
 	"autoload": {


### PR DESCRIPTION
- bug fix / new feature? Fix issue #401
- BC break? no

The `\SimpleXMLElement` class is used under the `src/` directory (see below) so the `simplexml` extension must be required to avoid a *class not found* error.

https://github.com/nette/tester/blob/0b33a936d28faa641f816b842020ae50f85ec6c3/src/Framework/DomQuery.php#L16