### PR TITLE
add global function test()

### DIFF
--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -36,6 +36,9 @@ class Environment
 	/** @var bool */
 	public static $useColors;
 
+	/** @var ?TestFunction */
+	public static $testFunction;
+
 	/** @var int initial output buffer level */
 	private static $obLevel;
 
@@ -50,6 +53,7 @@ class Environment
 	{
 		self::setupErrors();
 		self::setupColors();
+		self::setupFunctions();
 		self::$obLevel = ob_get_level();
 
 		class_exists(Runner\Job::class);
@@ -135,6 +139,19 @@ class Environment
 				}
 			});
 		});
+	}
+
+
+	/**
+	 * Creates global functions.
+	 */
+	public static function setupFunctions(): void
+	{
+		if (function_exists('test')) {
+			return;
+		}
+		self::$testFunction = new TestFunction;
+		require __DIR__ . '/functions.php';
 	}
 
 

--- a/src/Framework/TestFunction.php
+++ b/src/Framework/TestFunction.php
@@ -46,10 +46,10 @@ class TestFunction
 		}
 
 		if ($description !== '') {
-			echo empty($e)
-				? Dumper::color('lime', '√')
-				: Dumper::color('red', '×');
-			echo " $description\n";
+			$this->print(empty($e)
+				? Dumper::color('lime', '√') . " $description\n"
+				: Dumper::color('red', '×') . " $description\n\n"
+			);
 		}
 
 		if (isset($e)) {
@@ -58,6 +58,16 @@ class TestFunction
 
 		if ($this->after) {
 			($this->after)();
+		}
+	}
+
+
+	private function print(string $s): void
+	{
+		if (PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg') {
+			fwrite(STDOUT, $s);
+		} else {
+			echo $s;
 		}
 	}
 }

--- a/src/Framework/TestFunction.php
+++ b/src/Framework/TestFunction.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the Nette Tester.
+ * Copyright (c) 2009 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Tester;
+
+
+/**
+ * test(), beforeEach(), afterEach()
+ */
+class TestFunction
+{
+	/** ?\Closure */
+	private $before;
+
+	/** ?\Closure */
+	private $after;
+
+
+	public function beforeEach(?\Closure $fn): void
+	{
+		$this->before = $fn;
+	}
+
+
+	public function afterEach(?\Closure $fn): void
+	{
+		$this->after = $fn;
+	}
+
+
+	public function test(string $description, \Closure $fn): void
+	{
+		if ($this->before) {
+			($this->before)();
+		}
+
+		try {
+			$fn();
+		} catch (\Throwable $e) {
+		}
+
+		if ($description !== '') {
+			echo empty($e)
+				? Dumper::color('lime', '√')
+				: Dumper::color('red', '×');
+			echo " $description\n";
+		}
+
+		if (isset($e)) {
+			throw $e;
+		}
+
+		if ($this->after) {
+			($this->after)();
+		}
+	}
+}

--- a/src/Framework/functions.php
+++ b/src/Framework/functions.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+
+function beforeEach(?Closure $fn): void
+{
+	Tester\Environment::$testFunction->beforeEach($fn);
+}
+
+
+function afterEach(?Closure $fn): void
+{
+	Tester\Environment::$testFunction->afterEach($fn);
+}
+
+
+function test(string $description, Closure $fn): void
+{
+	Tester\Environment::$testFunction->test($description, $fn);
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -14,6 +14,7 @@ require __DIR__ . '/Framework/AssertException.php';
 require __DIR__ . '/Framework/Dumper.php';
 require __DIR__ . '/Framework/FileMock.php';
 require __DIR__ . '/Framework/TestCase.php';
+require __DIR__ . '/Framework/TestFunction.php';
 require __DIR__ . '/Framework/FileMutator.php';
 require __DIR__ . '/Framework/Expect.php';
 require __DIR__ . '/CodeCoverage/Collector.php';

--- a/tests/CodeCoverage/PhpParser.parse.lines-of-code.phpt
+++ b/tests/CodeCoverage/PhpParser.parse.lines-of-code.phpt
@@ -15,7 +15,7 @@ $parser = new CodeCoverage\PhpParser;
  * Assertions assume that every line is considered as a line of code.
  */
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse('<?php ');
 
 	Assert::same(1, $parsed->linesOfCode);
@@ -23,7 +23,7 @@ test(function () use ($parser) {
 });
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse("<?php\n");
 
 	Assert::same(1, $parsed->linesOfCode);
@@ -31,7 +31,7 @@ test(function () use ($parser) {
 });
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse("<?php\n// Comment\n");
 
 	Assert::same(2, $parsed->linesOfCode);
@@ -39,7 +39,7 @@ test(function () use ($parser) {
 });
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse("<?php\n/* Comment */\n");
 
 	Assert::same(2, $parsed->linesOfCode);
@@ -47,7 +47,7 @@ test(function () use ($parser) {
 });
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse("<?php\n/** Doc */\n");
 
 	Assert::same(2, $parsed->linesOfCode);
@@ -55,7 +55,7 @@ test(function () use ($parser) {
 });
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse("<?php\n/* Multi\nline\ncomment */\n");
 
 	Assert::same(4, $parsed->linesOfCode);
@@ -63,7 +63,7 @@ test(function () use ($parser) {
 });
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse("<?php\n/** Multi\n * doc\n * block\n **/\n");
 
 	Assert::same(5, $parsed->linesOfCode);

--- a/tests/CodeCoverage/PhpParser.parse.namespaces.phpt
+++ b/tests/CodeCoverage/PhpParser.parse.namespaces.phpt
@@ -12,7 +12,7 @@ require __DIR__ . '/../../src/CodeCoverage/PhpParser.php';
 $parser = new CodeCoverage\PhpParser;
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse(file_get_contents(__DIR__ . '/fixtures.parse/namespaces.none.php'));
 
 	Assert::equal([
@@ -33,7 +33,7 @@ test(function () use ($parser) {
 });
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse(file_get_contents(__DIR__ . '/fixtures.parse/namespaces.php'));
 
 	Assert::equal([
@@ -58,7 +58,7 @@ test(function () use ($parser) {
 });
 
 
-test(function () use ($parser) {
+test('', function () use ($parser) {
 	$parsed = $parser->parse(file_get_contents(__DIR__ . '/fixtures.parse/namespaces.braces.php'));
 
 	Assert::equal([

--- a/tests/Framework/DataProvider.load.phpt
+++ b/tests/Framework/DataProvider.load.phpt
@@ -8,7 +8,7 @@ use Tester\DataProvider;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () {
+test('', function () {
 	$expect = [
 		1 => [],
 		'foo' => [],
@@ -20,7 +20,7 @@ test(function () {
 });
 
 
-test(function () {
+test('', function () {
 	$expect = [
 		'bar 1.2.3' => ['a' => '1'],
 		'bar' => ['b' => '2'],

--- a/tests/Framework/DomQuery.css2Xpath.phpt
+++ b/tests/Framework/DomQuery.css2Xpath.phpt
@@ -7,26 +7,26 @@ use Tester\DomQuery;
 
 require __DIR__ . '/../bootstrap.php';
 
-test(function () { // type selectors
+test('type selectors', function () {
 	Assert::same('//*', DomQuery::css2xpath('*'));
 	Assert::same('//foo', DomQuery::css2xpath('foo'));
 });
 
 
-test(function () { // #ID
+test('#ID', function () {
 	Assert::same("//*[@id='foo']", DomQuery::css2xpath('#foo'));
 	Assert::same("//*[@id='id']", DomQuery::css2xpath('*#id'));
 });
 
 
-test(function () { // class
+test('class', function () {
 	Assert::same("//*[contains(concat(' ', normalize-space(@class), ' '), ' foo ')]", DomQuery::css2xpath('.foo'));
 	Assert::same("//*[contains(concat(' ', normalize-space(@class), ' '), ' foo ')]", DomQuery::css2xpath('*.foo'));
 	Assert::same("//*[contains(concat(' ', normalize-space(@class), ' '), ' foo ')][contains(concat(' ', normalize-space(@class), ' '), ' bar ')]", DomQuery::css2xpath('.foo.bar'));
 });
 
 
-test(function () { // attribute selectors
+test('attribute selectors', function () {
 	Assert::same('//div[@foo]', DomQuery::css2xpath('div[foo]'));
 	Assert::same("//div[@foo='bar']", DomQuery::css2xpath('div[foo=bar]'));
 	Assert::same("//*[@foo='bar']", DomQuery::css2xpath('[foo="bar"]'));
@@ -42,14 +42,14 @@ test(function () { // attribute selectors
 });
 
 
-test(function () { // variants
+test('variants', function () {
 	Assert::same("//*[@id='foo']|//*[@id='bar']", DomQuery::css2xpath('#foo, #bar'));
 	Assert::same("//*[@id='foo']|//*[@id='bar']", DomQuery::css2xpath('#foo,#bar'));
 	Assert::same("//*[@id='foo']|//*[@id='bar']", DomQuery::css2xpath('#foo ,#bar'));
 });
 
 
-test(function () { // descendant combinator
+test('descendant combinator', function () {
 	Assert::same(
 		"//div[@id='foo']//*[contains(concat(' ', normalize-space(@class), ' '), ' bar ')]",
 		DomQuery::css2xpath('div#foo .bar')
@@ -61,18 +61,18 @@ test(function () { // descendant combinator
 });
 
 
-test(function () { // child combinator
+test('child combinator', function () {
 	Assert::same("//div[@id='foo']/span", DomQuery::css2xpath('div#foo>span'));
 	Assert::same("//div[@id='foo']/span", DomQuery::css2xpath('div#foo > span'));
 });
 
 
-test(function () { // general sibling combinator
+test('general sibling combinator', function () {
 	Assert::same('//div/following-sibling::span', DomQuery::css2xpath('div ~ span'));
 });
 
 
-test(function () { // complex
+test('complex', function () {
 	Assert::same(
 		"//div[@id='foo']//span[contains(concat(' ', normalize-space(@class), ' '), ' bar ')]"
 		. "|//*[@id='bar']//li[contains(concat(' ', normalize-space(@class), ' '), ' baz ')]//a",
@@ -81,14 +81,14 @@ test(function () { // complex
 });
 
 
-test(function () { // pseudoclass
+test('pseudoclass', function () {
 	Assert::exception(function () {
 		DomQuery::css2xpath('a:first-child');
 	}, InvalidArgumentException::class);
 });
 
 
-test(function () { // adjacent sibling combinator
+test('adjacent sibling combinator', function () {
 	Assert::exception(function () {
 		DomQuery::css2xpath('div + span');
 	}, InvalidArgumentException::class);

--- a/tests/Framework/FileMock.phpt
+++ b/tests/Framework/FileMock.phpt
@@ -13,8 +13,7 @@ FileMock::create('');
 Assert::contains('mock', stream_get_wrappers());
 
 
-// Opening non-existing
-test(function () {
+test('Opening non-existing', function () {
 	$cases = [
 		'r' => $tmp = [
 			[E_USER_WARNING, 'fopen(mock://none): failed to open stream: No such file or directory'],
@@ -42,8 +41,7 @@ test(function () {
 });
 
 
-// Opening existing
-test(function () {
+test('Opening existing', function () {
 	FileMock::$files = [];
 
 	$cases = [
@@ -70,8 +68,7 @@ test(function () {
 });
 
 
-// Initial cursor position
-test(function () {
+test('Initial cursor position', function () {
 	FileMock::$files = [];
 
 	$cases = [
@@ -96,8 +93,7 @@ test(function () {
 });
 
 
-// Truncation on open
-test(function () {
+test('Truncation on open', function () {
 	FileMock::$files = [];
 
 	$cases = [
@@ -126,8 +122,7 @@ test(function () {
 	}
 });
 
-// Writing position after open
-test(function () {
+test('Writing position after open', function () {
 	FileMock::$files = [];
 
 	$cases = [
@@ -158,8 +153,7 @@ test(function () {
 });
 
 
-// Filesystem functions
-test(function () {
+test('Filesystem functions', function () {
 	$f = fopen($name = FileMock::create('', 'txt'), 'w+');
 
 	Assert::match('%a%.txt', $name);
@@ -206,8 +200,7 @@ test(function () {
 });
 
 
-// Unlink
-test(function () {
+test('Unlink', function () {
 	fopen($name = Tester\FileMock::create('foo'), 'r');
 	Assert::true(unlink($name));
 	Assert::false(@unlink($name));
@@ -217,20 +210,17 @@ test(function () {
 });
 
 
-// Runtime include
-test(function () {
+test('Runtime include', function () {
 	Assert::same(123, require FileMock::create('<?php return 123;'));
 });
 
 
-// Locking
-test(function () {
+test('Locking', function () {
 	Assert::false(flock(fopen(FileMock::create(''), 'w'), LOCK_EX));
 });
 
 
-// Position handling across modes
-test(function () {
+test('Position handling across modes', function () {
 	$modes = ['r', 'r+', 'w', 'w+', 'a', 'a+', 'c', 'c+'];
 	$pathReal = __DIR__ . '/real-file.txt';
 
@@ -264,8 +254,7 @@ test(function () {
 });
 
 
-// touch
-test(function () {
+test('touch', function () {
 	fopen($name = Tester\FileMock::create('foo'), 'r');
 	Assert::true(touch($name));
 });

--- a/tests/Runner/CommandLine.phpt
+++ b/tests/Runner/CommandLine.phpt
@@ -10,7 +10,7 @@ require __DIR__ . '/../../src/Runner/CommandLine.php';
 
 
 
-test(function () {
+test('', function () {
 	$cmd = new Cmd('
 		-p
 		--p
@@ -29,7 +29,7 @@ test(function () {
 });
 
 
-test(function () { // default value
+test('default value', function () {
 	$cmd = new Cmd('
 		-p  (default: 123)
 	');
@@ -49,7 +49,7 @@ test(function () { // default value
 });
 
 
-test(function () { // alias
+test('alias', function () {
 	$cmd = new Cmd('
 		-p | --param
 	');
@@ -76,7 +76,7 @@ test(function () { // alias
 });
 
 
-test(function () { // argument
+test('argument', function () {
 	$cmd = new Cmd('
 		-p param
 	');
@@ -104,7 +104,7 @@ test(function () { // argument
 
 
 
-test(function () { // optional argument
+test('optional argument', function () {
 	$cmd = new Cmd('
 		-p [param]
 	');
@@ -138,7 +138,7 @@ test(function () { // optional argument
 
 
 
-test(function () { // repeatable argument
+test('repeatable argument', function () {
 	$cmd = new Cmd('
 		-p [param]...
 	');
@@ -151,7 +151,7 @@ test(function () { // repeatable argument
 
 
 
-test(function () { // enumerates
+test('enumerates', function () {
 	$cmd = new Cmd('
 		-p <a|b|c>
 	');
@@ -180,7 +180,7 @@ test(function () { // enumerates
 
 
 
-test(function () { // realpath
+test('realpath', function () {
 	$cmd = new Cmd('
 		-p <path>
 	', [
@@ -195,7 +195,7 @@ test(function () { // realpath
 
 
 
-test(function () { // positional arguments
+test('positional arguments', function () {
 	$cmd = new Cmd('', [
 		'pos' => [],
 	]);
@@ -233,7 +233,7 @@ test(function () { // positional arguments
 
 
 
-test(function () { // errors
+test('errors', function () {
 	$cmd = new Cmd('
 		-p
 	');

--- a/tests/Runner/Job.phpt
+++ b/tests/Runner/Job.phpt
@@ -10,7 +10,7 @@ require __DIR__ . '/../../src/Runner/Test.php';
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () {
+test('', function () {
 	$test = (new Test('Job.test.phptx'))->withArguments(['one', 'two' => 1])->withArguments(['three', 'two' => 2]);
 	$job = new Job($test, createInterpreter());
 	$job->run($job::RUN_COLLECT_ERRORS);

--- a/tests/Runner/Runner.stop-on-fail.phpt
+++ b/tests/Runner/Runner.stop-on-fail.phpt
@@ -42,8 +42,7 @@ class Logger implements Tester\Runner\OutputHandler
 $interpreter = createInterpreter();
 
 
-// Normal stop on the end
-test(function () use ($interpreter) {
+test('Normal stop on the end', function () use ($interpreter) {
 	$runner = new Runner($interpreter);
 	$runner->outputHandlers[] = $logger = new Logger;
 	$runner->paths = [
@@ -61,8 +60,7 @@ test(function () use ($interpreter) {
 });
 
 
-// Stop in initial phase
-test(function () use ($interpreter) {
+test('Stop in initial phase', function () use ($interpreter) {
 	$runner = new Runner($interpreter);
 	$runner->outputHandlers[] = $logger = new Logger;
 	$runner->stopOnFail = true;
@@ -78,8 +76,7 @@ test(function () use ($interpreter) {
 });
 
 
-// Stop in run-time
-test(function () use ($interpreter) {
+test('Stop in run-time', function () use ($interpreter) {
 	$runner = new Runner($interpreter);
 	$runner->outputHandlers[] = $logger = new Logger;
 	$runner->stopOnFail = true;

--- a/tests/Runner/Test.phpt
+++ b/tests/Runner/Test.phpt
@@ -13,7 +13,7 @@ require __DIR__ . '/../../src/Runner/Test.php';
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () {
+test('', function () {
 	$test = new Test('some/Test.phpt');
 
 	Assert::null($test->title);
@@ -28,14 +28,14 @@ test(function () {
 });
 
 
-test(function () {
+test('', function () {
 	$test = new Test(__FILE__, 'My test');
 
 	Assert::same('My test', $test->title);
 });
 
 
-test(function () {
+test('', function () {
 	$test = (new Test(__FILE__, 'My test'))->withResult(Test::PASSED, 'It is done');
 
 	Assert::true($test->hasResult());
@@ -48,7 +48,7 @@ test(function () {
 });
 
 
-test(function () {
+test('', function () {
 	$test = new Test(__FILE__, 'My test');
 
 	$test = $test->withArguments(['one', 'two' => 1]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,12 +12,6 @@ require __DIR__ . '/../src/Runner/PhpInterpreter.php';
 date_default_timezone_set('Europe/Prague');
 
 
-function test(string $description, Closure $function): void
-{
-	$function();
-}
-
-
 function createInterpreter(): PhpInterpreter
 {
 	$args = strlen((string) php_ini_scanned_files())

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,7 +12,7 @@ require __DIR__ . '/../src/Runner/PhpInterpreter.php';
 date_default_timezone_set('Europe/Prague');
 
 
-function test(\Closure $function): void
+function test(string $description, Closure $function): void
 {
 	$function();
 }


### PR DESCRIPTION
This is similar to the `test()` function, which is actually used by all Nette libraries. In addition, the test name is passed to the function and it lists results.

![image](https://user-images.githubusercontent.com/194960/90337195-38b14a00-dfe1-11ea-90bd-3903f904ef07.png)
(https://github.com/nette/utils/blob/be6f0157dbb500c90ad0762a32a0681e087a6be3/tests/Utils/Arrays.insertBefore().phpt#L24-L72)

It also adds the `beforeEach()` and `afterEach()` functions.

What to consider
- The function is only created if it does not exist, which should prevent collisions. Maybe it could be controlled in any other way.
- switch whether to continue to the next `test()` function if assertion fails
- switch to turn off output
- output directly to STDOUT, so it cannot then be controlled by an output buffer
- consider using the TestCase for before/after execution, similary to setUp/tearDown




