### PR TITLE
fix Assert::type() failure error when expected $type is object

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -273,6 +273,7 @@ class Assert
 
 		} elseif (!$value instanceof $type) {
 			$actual = is_object($value) ? get_class($value) : gettype($value);
+			$type = is_object($type) ? get_class($type) : $type;
 			self::fail(self::describe("$actual should be instance of $type", $description));
 		}
 	}

--- a/tests/Framework/Assert.type.phpt
+++ b/tests/Framework/Assert.type.phpt
@@ -28,6 +28,7 @@ $cases = [
 	['list', []],
 	['list', [1]],
 	['list', [4 => 1], '[4 => 1] should be list'],
+	[new stdClass, 'string', 'string should be instance of stdClass'],
 ];
 
 foreach ($cases as $case) {


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: not necessary

Apparently `Assert::type()` supports an object instance in place of expected `$type`, but if such assertion fails, building a failure message produces either an `Error: Object of class (...) could not be converted to string`, or a rather misleading message if the expected type implements `__toString`.