### PR TITLE
Add hasKey and hasNotKey assertions

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -148,10 +148,10 @@ class Assert
 		self::$counter++;
 		if (is_array($actual)) {
 			if (!array_key_exists($key, $actual)) {
-				self::fail(self::describe('%1 should contain key %2', $description), $actual, $key);
+				self::fail(self::describe('Array should contain key %1', $description), $key);
 			}
 		} else {
-			self::fail(self::describe('%1 should be array', $description), $actual);
+			self::fail(self::describe('Input should be array', $description));
 		}
 	}
 
@@ -163,10 +163,10 @@ class Assert
 		self::$counter++;
 		if (is_array($actual)) {
 			if (array_key_exists($key, $actual)) {
-				self::fail(self::describe('%1 should not contain key %2', $description), $actual, $key);
+				self::fail(self::describe('Array should not contain key %1', $description), $key);
 			}
 		} else {
-			self::fail(self::describe('%1 should be array', $description), $actual);
+			self::fail(self::describe('Input should be array', $description));
 		}
 	}
 

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -141,8 +141,8 @@ class Assert
 	}
 	
 	/**
-         * Asserts that a haystack (string or array) has an expected key.
-         */
+	 * Asserts that a haystack (string or array) has an expected key.
+	 */
         public static function hasKey($key, $actual, string $description = null): void
         {
 		self::$counter++;
@@ -156,8 +156,8 @@ class Assert
 	}
 
         /**
-         * Asserts that a haystack (string or array) doesnt have an expected key.
-         */
+	 * Asserts that a haystack (string or array) doesnt have an expected key.
+	 */
         public static function hasNotKey($key, $actual, string $description = null): void
         {
 		self::$counter++;

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -143,8 +143,8 @@ class Assert
 	/**
 	 * Asserts that a haystack (string or array) has an expected key.
 	 */
-        public static function hasKey($key, $actual, string $description = null): void
-        {
+	public static function hasKey($key, $actual, string $description = null): void
+	{
 		self::$counter++;
 		if (is_array($actual)) {
 			if (!array_key_exists($key, $actual)) {
@@ -155,11 +155,11 @@ class Assert
 		}
 	}
 
-        /**
+	/**
 	 * Asserts that a haystack (string or array) doesnt have an expected key.
 	 */
-        public static function hasNotKey($key, $actual, string $description = null): void
-        {
+	public static function hasNotKey($key, $actual, string $description = null): void
+	{
 		self::$counter++;
 		if (is_array($actual)) {
 			if (array_key_exists($key, $actual)) {

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -139,6 +139,36 @@ class Assert
 			self::fail(self::describe('%1 should be string or array', $description), $actual);
 		}
 	}
+	
+	/**
+         * Asserts that a haystack (string or array) has an expected key.
+         */
+        public static function hasKey($key, $actual, string $description = null): void
+        {
+		self::$counter++;
+		if (is_array($actual)) {
+			if (!array_key_exists($key, $actual)) {
+				self::fail(self::describe('%1 should contain key %2', $description), $actual, $key);
+			}
+		} else {
+			self::fail(self::describe('%1 should be array', $description), $actual);
+		}
+	}
+
+        /**
+         * Asserts that a haystack (string or array) doesnt have an expected key.
+         */
+        public static function hasNotKey($key, $actual, string $description = null): void
+        {
+		self::$counter++;
+		if (is_array($actual)) {
+			if (array_key_exists($key, $actual)) {
+				self::fail(self::describe('%1 should not contain key %2', $description), $actual, $key);
+			}
+		} else {
+			self::fail(self::describe('%1 should be array', $description), $actual);
+		}
+	}
 
 
 	/**

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -148,10 +148,10 @@ class Assert
 		self::$counter++;
 		if (is_array($actual)) {
 			if (!array_key_exists($key, $actual)) {
-				self::fail(self::describe('Array should contain key %1', $description), $key);
+				self::fail(self::describe('%1 should contain key %2', $description), $actual, $key);
 			}
 		} else {
-			self::fail(self::describe('Input should be array', $description));
+			self::fail(self::describe('%1 should be array', $description), $actual);
 		}
 	}
 
@@ -163,10 +163,10 @@ class Assert
 		self::$counter++;
 		if (is_array($actual)) {
 			if (array_key_exists($key, $actual)) {
-				self::fail(self::describe('Array should not contain key %1', $description), $key);
+				self::fail(self::describe('%1 should not contain key %2', $description), $actual, $key);
 			}
 		} else {
-			self::fail(self::describe('Input should be array', $description));
+			self::fail(self::describe('%1 should be array', $description), $actual);
 		}
 	}
 

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -140,6 +140,7 @@ class Assert
 		}
 	}
 
+
 	/**
 	 * Asserts that a haystack (string or array) has an expected key.
 	 */
@@ -154,6 +155,7 @@ class Assert
 			self::fail(self::describe('%1 should be array', $description), $actual);
 		}
 	}
+
 
 	/**
 	 * Asserts that a haystack (string or array) doesnt have an expected key.

--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -139,7 +139,7 @@ class Assert
 			self::fail(self::describe('%1 should be string or array', $description), $actual);
 		}
 	}
-	
+
 	/**
 	 * Asserts that a haystack (string or array) has an expected key.
 	 */

--- a/tests/Framework/Assert.hasKey.phpt
+++ b/tests/Framework/Assert.hasKey.phpt
@@ -8,8 +8,8 @@ require __DIR__ . '/../bootstrap.php';
 
 
 $array = [
-  1 => 1,
-  "one" => "one",
+	1 => 1,
+	"one" => "one",
 ];
 
 $string= "Lorem ipsum";

--- a/tests/Framework/Assert.hasKey.phpt
+++ b/tests/Framework/Assert.hasKey.phpt
@@ -9,42 +9,42 @@ require __DIR__ . '/../bootstrap.php';
 
 $array = [
 	1 => 1,
-	"one" => "one",
+	'one' => 'one',
 ];
 
-$string= "Lorem ipsum";
+$string= 'Lorem ipsum';
 
 Assert::hasKey(1, $array);
-Assert::hasKey("one", $array);
+Assert::hasKey('one', $array);
 
 Assert::hasNotKey(2, $array);
-Assert::hasNotKey("two", $array);
+Assert::hasNotKey('two', $array);
 
 Assert::exception(function () use ($array) {
-		Assert::hasKey(2, $array);
-	}, Tester\AssertException::class, '%a% should contain key %a%');
+	Assert::hasKey(2, $array);
+}, Tester\AssertException::class, '%a% should contain key %a%');
 
 Assert::exception(function () use ($array) {
-		Assert::hasKey("two", $array);
-	}, Tester\AssertException::class, '%a% should contain key %a%');
+	Assert::hasKey('two', $array);
+}, Tester\AssertException::class, '%a% should contain key %a%');
 
 Assert::exception(function () use ($string) {
-		Assert::hasKey("two", $string);
-	}, Tester\AssertException::class, '%a% should be array');
+	Assert::hasKey('two', $string);
+}, Tester\AssertException::class, '%a% should be array');
 
 
 Assert::exception(function () use ($array) {
-		Assert::hasNotKey(1, $array);
-	}, Tester\AssertException::class, '%a% should not contain key %a%');
+	Assert::hasNotKey(1, $array);
+}, Tester\AssertException::class, '%a% should not contain key %a%');
 
 Assert::exception(function () use ($array) {
-		Assert::hasNotKey("one", $array);
-	}, Tester\AssertException::class, '%a% should not contain key %a%');
+	Assert::hasNotKey('one', $array);
+}, Tester\AssertException::class, '%a% should not contain key %a%');
 
 
 Assert::exception(function () use ($string) {
-		Assert::hasNotKey("two", $string);
-	}, Tester\AssertException::class, '%a% should be array');
+	Assert::hasNotKey('two', $string);
+}, Tester\AssertException::class, '%a% should be array');
 
 Assert::exception(function () use ($array) {
 	Assert::hasKey('two', $array, 'Custom description');

--- a/tests/Framework/Assert.hasKey.phpt
+++ b/tests/Framework/Assert.hasKey.phpt
@@ -48,8 +48,8 @@ Assert::exception(function () use ($string) {
 
 Assert::exception(function () use ($array) {
 	Assert::hasKey('two', $array, 'Custom description');
-}, Tester\AssertException::class, "Custom description: %a% should contain 'two'");
+}, Tester\AssertException::class, "Custom description: [1 => 1, 'one' => 'one'] should contain 'two'");
 
 Assert::exception(function () use ($array) {
 	Assert::hasNotKey('one', $array, 'Custom description');
-}, Tester\AssertException::class, "Custom description: %a% should not contain 'one'");
+}, Tester\AssertException::class, "Custom description: [1 => 1, 'one' => 'one'] should not contain 'one'");

--- a/tests/Framework/Assert.hasKey.phpt
+++ b/tests/Framework/Assert.hasKey.phpt
@@ -48,8 +48,8 @@ Assert::exception(function () use ($string) {
 
 Assert::exception(function () use ($array) {
 	Assert::hasKey('two', $array, 'Custom description');
-}, Tester\AssertException::class, "Custom description: [1 => 1, 'one' => 'one'] should contain 'two'");
+}, Tester\AssertException::class, "Custom description: [1 => 1, 'one' => 'one'] should contain key 'two'");
 
 Assert::exception(function () use ($array) {
 	Assert::hasNotKey('one', $array, 'Custom description');
-}, Tester\AssertException::class, "Custom description: [1 => 1, 'one' => 'one'] should not contain 'one'");
+}, Tester\AssertException::class, "Custom description: [1 => 1, 'one' => 'one'] should not contain key 'one'");

--- a/tests/Framework/Assert.hasKey.phpt
+++ b/tests/Framework/Assert.hasKey.phpt
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$array = [
+  1 => 1,
+  "one" => "one",
+];
+
+$string= "Lorem ipsum";
+
+Assert::hasKey(1, $array);
+Assert::hasKey("one", $array);
+
+Assert::hasNotKey(2, $array);
+Assert::hasNotKey("two", $array);
+
+Assert::exception(function () use ($array) {
+		Assert::hasKey(2, $array);
+	}, Tester\AssertException::class, '%a% should contain key %a%');
+
+Assert::exception(function () use ($array) {
+		Assert::hasKey("two", $array);
+	}, Tester\AssertException::class, '%a% should contain key %a%');
+
+Assert::exception(function () use ($string) {
+		Assert::hasKey("two", $string);
+	}, Tester\AssertException::class, '%a% should be array');
+
+
+Assert::exception(function () use ($array) {
+		Assert::hasNotKey(1, $array);
+	}, Tester\AssertException::class, '%a% should not contain key %a%');
+
+Assert::exception(function () use ($array) {
+		Assert::hasNotKey("one", $array);
+	}, Tester\AssertException::class, '%a% should not contain key %a%');
+
+
+Assert::exception(function () use ($string) {
+		Assert::hasNotKey("two", $string);
+	}, Tester\AssertException::class, '%a% should be array');
+
+Assert::exception(function () use ($array) {
+	Assert::hasKey('two', $array, 'Custom description');
+}, Tester\AssertException::class, "Custom description: %a% should contain 'two'");
+
+Assert::exception(function () use ($array) {
+	Assert::hasNotKey('one', $array, 'Custom description');
+}, Tester\AssertException::class, "Custom description: %a% should not contain 'one'");


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: nette/docs#???  On its way

Add simple assertions hasKey nad hasNotKey to tester. They are very useful for testing restful api responses.

Tests included.
