### PR TITLE
Fix integer-indexed cases

### DIFF
--- a/src/Framework/DataProvider.php
+++ b/src/Framework/DataProvider.php
@@ -44,7 +44,7 @@ class DataProvider
 		}
 
 		foreach ($data as $key => $value) {
-			if (!is_int($key) && !self::testQuery($key, $query)) {
+			if (!self::testQuery((string) $key, $query)) {
 				unset($data[$key]);
 			}
 		}

--- a/tests/Framework/DataProvider.load.phpt
+++ b/tests/Framework/DataProvider.load.phpt
@@ -10,13 +10,19 @@ require __DIR__ . '/../bootstrap.php';
 
 test(function () {
 	$expect = [
-		1 => [],
+		1 => ['integer' => 'abc'],
+		2 => ['integer' => 'def'],
 		'foo' => [],
 		'bar' => [],
 	];
 
 	Assert::same($expect, DataProvider::load('fixtures/dataprovider.ini'));
 	Assert::same($expect, DataProvider::load('fixtures/dataprovider.php'));
+
+	foreach (array_keys($expect) as $key) {
+		Assert::same([$key => $expect[$key]], DataProvider::load('fixtures/dataprovider.ini', (string) $key));
+		Assert::same([$key => $expect[$key]], DataProvider::load('fixtures/dataprovider.php', (string) $key));
+	}
 });
 
 

--- a/tests/Framework/fixtures/dataprovider.ini
+++ b/tests/Framework/fixtures/dataprovider.ini
@@ -1,4 +1,8 @@
 [1]
+integer = abc
+
+[2]
+integer = def
 
 [foo]
 

--- a/tests/Framework/fixtures/dataprovider.php
+++ b/tests/Framework/fixtures/dataprovider.php
@@ -1,7 +1,8 @@
 <?php
 
 return [
-	1 => [], // integer key
+	1 => ['integer' => 'abc'], // first integer key
+	2 => ['integer' => 'def'], // second integer key
 	'foo' => [],
 	'bar' => [],
 ];

--- a/tests/Runner/Runner.multiple.phpt
+++ b/tests/Runner/Runner.multiple.phpt
@@ -31,12 +31,15 @@ $path = __DIR__ . DIRECTORY_SEPARATOR . 'multiple' . DIRECTORY_SEPARATOR;
 Assert::same([
 	['dataProvider.multiple.phptx', [['dataprovider', "1|$path../../Framework/fixtures/dataprovider.ini"], ['multiple', '0']]],
 	['dataProvider.multiple.phptx', [['dataprovider', "1|$path../../Framework/fixtures/dataprovider.ini"], ['multiple', '1']]],
+	['dataProvider.multiple.phptx', [['dataprovider', "2|$path../../Framework/fixtures/dataprovider.ini"], ['multiple', '0']]],
+	['dataProvider.multiple.phptx', [['dataprovider', "2|$path../../Framework/fixtures/dataprovider.ini"], ['multiple', '1']]],
 	['dataProvider.multiple.phptx', [['dataprovider', "bar|$path../../Framework/fixtures/dataprovider.ini"], ['multiple', '0']]],
 	['dataProvider.multiple.phptx', [['dataprovider', "bar|$path../../Framework/fixtures/dataprovider.ini"], ['multiple', '1']]],
 	['dataProvider.multiple.phptx', [['dataprovider', "foo|$path../../Framework/fixtures/dataprovider.ini"], ['multiple', '0']]],
 	['dataProvider.multiple.phptx', [['dataprovider', "foo|$path../../Framework/fixtures/dataprovider.ini"], ['multiple', '1']]],
 
 	['dataProvider.phptx', [['dataprovider', "1|$path../../Framework/fixtures/dataprovider.ini"]]],
+	['dataProvider.phptx', [['dataprovider', "2|$path../../Framework/fixtures/dataprovider.ini"]]],
 	['dataProvider.phptx', [['dataprovider', "bar|$path../../Framework/fixtures/dataprovider.ini"]]],
 	['dataProvider.phptx', [['dataprovider', "foo|$path../../Framework/fixtures/dataprovider.ini"]]],
 


### PR DESCRIPTION
- **bug fix**
- BC break? *not sure to be honest*
- doc PR: *shouldn't be needed*

### Description
Currently when PHP @dataProvider returns integer-indexed cases (simply array), in each run the first case is used.

### Example
Given following test:
```php
[$expected, $actual] = Tester\Environment::loadData();
Tester\Assert::same($expected, $actual);
```

With following data provider, all 3 cases will fail:
```php
return [
    ['foo', 'bar'],
    ['foo', 'foo'],
    ['foo', 'foo'],
];
```

With following data provider, all 3 cases will succeed:
```php
return [
    ['foo', 'foo'],
    ['foo', 'bar'],
    ['foo', 'bar'],
];
```

### Summary
That's what this PR fixes :)