### PR TITLE
CliTester: added missing newline

### DIFF
--- a/src/Runner/CliTester.php
+++ b/src/Runner/CliTester.php
@@ -298,7 +298,7 @@ XX
 			echo 'Generating code coverage report... ';
 		}
 		if (filesize($file) === 0) {
-			echo 'failed. Coverage file is empty. Do you call Tester\Environment::setup() in tests?';
+			echo 'failed. Coverage file is empty. Do you call Tester\Environment::setup() in tests?' . "\n";
 			return;
 		}
 		$generator = pathinfo($file, PATHINFO_EXTENSION) === 'xml'


### PR DESCRIPTION
- bug fix
- BC break? no

Added new line at the end to avoid this:
Generating code coverage report... failed. Coverage file is empty. Do you call Tester\Environment::setup() in tests?diego@localhost $
