### PR TITLE
Dumper: create output directory recursively

### DIFF
--- a/src/Framework/Dumper.php
+++ b/src/Framework/Dumper.php
@@ -352,7 +352,7 @@ class Dumper
 		if (!preg_match('#/|\w:#A', self::$dumpDir)) {
 			$path = dirname($testFile) . DIRECTORY_SEPARATOR . $path;
 		}
-		@mkdir(dirname($path)); // @ - directory may already exist
+		@mkdir(dirname($path), 0777, true); // @ - directory may already exist
 		file_put_contents($path, is_string($content) ? $content : (self::toPhp($content) . "\n"));
 		return $path;
 	}


### PR DESCRIPTION
- new feature
- BC break? no

Just create dumper output directory recursively - it's handy when someone use a custom directory path for output files.