### PR TITLE
TestHandler: mark tests with empty data provider as failed/skipped

### DIFF
--- a/src/Runner/TestHandler.php
+++ b/src/Runner/TestHandler.php
@@ -146,6 +146,10 @@ class TestHandler
 		try {
 			[$dataFile, $query, $optional] = Tester\DataProvider::parseAnnotation($provider, $test->getFile());
 			$data = Tester\DataProvider::load($dataFile, $query);
+			if (count($data) < 1) {
+				throw new \Exception("No records in data provider file '{$test->getFile()}'" . ($query ? " for query '$query'" : '') . '.');
+			}
+
 		} catch (\Exception $e) {
 			return $test->withResult(empty($optional) ? Test::FAILED : Test::SKIPPED, $e->getMessage());
 		}

--- a/tests/Runner/Runner.multiple-fails.phpt
+++ b/tests/Runner/Runner.multiple-fails.phpt
@@ -50,6 +50,13 @@ $runner->outputHandlers[] = $logger = new Logger;
 $runner->run();
 
 Assert::match(
+	"No records in data provider file '%a%dataprovider-empty.phptx' for query 'non-existent'.",
+	$logger->results['dataprovider-empty.phptx'][1]
+);
+Assert::same(Test::FAILED, $logger->results['dataprovider-empty.phptx'][0]);
+
+
+Assert::match(
 	"Class MyTest in file '%a%testcase-no-methods.phptx' does not contain test methods.",
 	$logger->results['testcase-no-methods.phptx'][1]
 );
@@ -93,4 +100,4 @@ Assert::match(
 Assert::same(Test::SKIPPED, $logger->results['testcase-skip.phptx'][0]);
 
 
-Assert::same(6, count($logger->results));
+Assert::same(7, count($logger->results));

--- a/tests/Runner/multiple-fails/dataprovider-empty.phptx
+++ b/tests/Runner/multiple-fails/dataprovider-empty.phptx
@@ -1,0 +1,5 @@
+<?php
+
+/**
+ * @dataProvider  ../../Framework/fixtures/dataprovider.query.ini, non-existent
+ */


### PR DESCRIPTION
Related to 1f4bce20a4142f5b1285d1eb9ae546ed5ef27e06
