### PR TITLE
Setup colors in TestCase

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -35,6 +35,7 @@ class TestCase
 			throw new \LogicException('Calling TestCase::run($method) is deprecated. Use TestCase::runTest($method) instead.');
 		}
 
+		Environment::setupColors();
 		$methods = array_values(preg_grep(
 			self::MethodPattern,
 			array_map(fn(\ReflectionMethod $rm): string => $rm->getName(), (new \ReflectionObject($this))->getMethods())


### PR DESCRIPTION
- bug fix / new feature?   bug fix (I'm running Tester 2.5.0)
- BC break? no

If not set up, "Typed static property Tester\Environment::$useColors must not be accessed before initialization in .../Framework/Environment.php:267" is thrown when `\Tester\Environment::setup()` is not called in the TestCase-based test file.

Without the patch:
```
$ vendor/nette/tester/src/tester -c tests/php-unix.ini tests/
 _____ ___  ___ _____ ___  ___
|_   _/ __)( __/_   _/ __)| _ )
  |_| \___ /___) |_| \___ |_|_\  v2.5.0

PHP 8.2.5 (cli) | php -n -c [...]/php-unix.ini | 8 threads

............F

-- FAILED: ConfigExtensionTest.phpt
   Exited with error code 255 (expected 0)

   Fatal error: Uncaught Error: Typed static property Tester\Environment::$useColors must not be accessed before initialization in [...]vendor/nette/tester/src/Framework/Environment.php:267
   Stack trace:
   #0 [...]vendor/nette/tester/src/Framework/TestCase.php(63): Tester\Environment::print('\e[1m\e[31m\xC3\x97\e[0m...')
   #1 [...]tests/ConfigExtensionTest.phpt(85): Tester\TestCase->run()
   #2 {main}
     thrown in [...]vendor/nette/tester/src/Framework/Environment.php on line 267


FAILURES! (13 tests, 1 failure, 1.6 seconds)
```

With the patch:
```
$ vendor/nette/tester/src/tester -c tests/php-unix.ini tests/
 _____ ___  ___ _____ ___  ___
|_   _/ __)( __/_   _/ __)| _ )
  |_| \___ /___) |_| \___ |_|_\  v2.5.0

PHP 8.2.5 (cli) | php -n -c [...]/php-unix.ini | 8 threads

............F

-- FAILED: ConfigExtensionTest.phpt
   Exited with error code 255 (expected 0)
   √ testService
   × testConfig
[...]
```

Adding `\Tester\Environment::setup();` to the testcase file also fixes the problem, for example:

```php
// [...]
require __DIR__ . '/../vendor/autoload.php';
\Tester\Environment::setup();

class ConfigExtensionTest extends TestCase
// [...]
```
But I believe calling it should not be necessary (I have seen the `Environment::setup()` notes in the README and the docs).

I'm a Tester internals noob and am not sure if this is the right way, let me know if that's not the case. I've added the call because I've seen a similar call in here:
https://github.com/nette/tester/blob/869cb00eb3059f6af0bbf33600a03e6b3d8ec3c4/src/Runner/CliTester.php#L31
