### PR TITLE
fixed accessed property before initialization

### DIFF
--- a/src/Framework/Environment.php
+++ b/src/Framework/Environment.php
@@ -46,7 +46,7 @@ class Environment
 	public const THREAD = self::VariableThread;
 
 	public static bool $checkAssertions = false;
-	public static bool $useColors;
+	public static bool $useColors = false;
 	private static int $exitCode = 0;
 
 


### PR DESCRIPTION
- bug fix
- BC break? no

This is alternative for fixing issue described in #441. 

Why am I doing a second PR? Because I think that hitting `src/Framework/TestCase.php` is not good. That's why I'm defining the property to the default value in the PR.

Why did the code work before? PHP dynamically initialized the property to null. But after adding a type, it starts to fail. Via sample https://3v4l.org/dmghh Commit hash that clogged this problem [e445e74b](https://github.com/nette/tester/commit/e445e74b8a16bbdfa8222b46edd5d377dd435cd8#diff-739a29dbff2caac04e06818e0ac275ee2983c85b8f75624ce3c08c96835d95c0R34). 

Sample error on URL https://github.com/php-parallel-lint/PHP-Parallel-Lint/actions/runs/4834553343/jobs/8615917976