### PR TITLE
Added `console-lines` output mode which prints each test on a separate line

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
 	level: 5
-
 	paths:
 		- src
+	typeAliases:
+		Alias_TestResultState: 'Tester\Runner\Test::Passed|Tester\Runner\Test::Skipped|Tester\Runner\Test::Failed|Tester\Runner\Test::Prepared'

--- a/readme.md
+++ b/readme.md
@@ -223,7 +223,8 @@ Options:
     -s                           Show information about skipped tests.
     --stop-on-fail               Stop execution upon the first failure.
     -j <num>                     Run <num> jobs in parallel (default: 8).
-    -o <console|tap|junit|none>  Specify output format.
+    -o <console|console-lines|tap|junit|none>
+                                 Specify output format.
     -w | --watch <path>          Watch directory.
     -i | --info                  Show tests environment info and exit.
     --setup <path>               Script for runner setup.

--- a/src/Runner/Output/ConsolePrinter.php
+++ b/src/Runner/Output/ConsolePrinter.php
@@ -20,46 +20,66 @@ use Tester\Runner\Test;
  */
 class ConsolePrinter implements Tester\Runner\OutputHandler
 {
-	private Runner $runner;
-
 	/** @var resource */
 	private $file;
-	private bool $displaySkipped = false;
-	private string $buffer;
-	private float $time;
-	private int $count;
-	private array $results;
-	private ?string $baseDir;
+
+	/** @var list<string> */
+	private array $buffer;
+
+	/**
+	 * @phpstan-var array<Alias_TestResultState, string>
+	 * @var array<int, string>
+	 */
 	private array $symbols;
 
+	/**
+	 * @phpstan-var array<Alias_TestResultState, int>
+	 * @var array<int, string>
+	 */
+	private array $results = [
+		Test::Passed => 0,
+		Test::Skipped => 0,
+		Test::Failed => 0,
+	];
 
+	private float $time;
+	private int $count;
+	private ?string $baseDir;
+	private int $resultsCount = 0;
+
+	/**
+	 * @param bool $lineMode If `true`, reports each finished test on separate line.
+	 */
 	public function __construct(
-		Runner $runner,
-		bool $displaySkipped = false,
+		private Runner $runner,
+		private bool $displaySkipped = false,
 		?string $file = null,
-		bool $ciderMode = false
+		bool $ciderMode = false,
+		private bool $lineMode = false,
 	) {
 		$this->runner = $runner;
 		$this->displaySkipped = $displaySkipped;
 		$this->file = fopen($file ?: 'php://output', 'w');
+
 		$this->symbols = [
-			Test::Passed => $ciderMode ? Dumper::color('green', '🍎') : '.',
-			Test::Skipped => 's',
-			Test::Failed => $ciderMode ? Dumper::color('red', '🍎') : Dumper::color('white/red', 'F'),
+			Test::Passed => $this->lineMode ? Dumper::color('lime', 'OK') : '.',
+			Test::Skipped => $this->lineMode ? Dumper::color('yellow', 'SKIP') : 's',
+			Test::Failed => $this->lineMode ? Dumper::color('white/red', 'FAIL') : Dumper::color('white/red', 'F'),
 		];
+
+		if ($ciderMode) {
+			$this->symbols[Test::Passed] = '🍏';
+			$this->symbols[Test::Skipped] = '🍋';
+			$this->symbols[Test::Failed] = '🍎';
+		}
 	}
 
 
 	public function begin(): void
 	{
 		$this->count = 0;
-		$this->buffer = '';
+		$this->buffer = [];
 		$this->baseDir = null;
-		$this->results = [
-			Test::Passed => 0,
-			Test::Skipped => 0,
-			Test::Failed => 0,
-		];
 		$this->time = -microtime(true);
 		fwrite($this->file, $this->runner->getInterpreter()->getShortInfo()
 			. ' | ' . $this->runner->getInterpreter()->getCommandLine()
@@ -94,15 +114,17 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 	public function finish(Test $test): void
 	{
 		$this->results[$test->getResult()]++;
-		fwrite($this->file, $this->symbols[$test->getResult()]);
+		$this->lineMode
+			? $this->printFinishedTestLine($test)
+			: $this->printFinishedTestDot($test);
 
 		$title = ($test->title ? "$test->title | " : '') . substr($test->getSignature(), strlen($this->baseDir));
 		$message = '   ' . str_replace("\n", "\n   ", trim((string) $test->message)) . "\n\n";
 		$message = preg_replace('/^   $/m', '', $message);
 		if ($test->getResult() === Test::Failed) {
-			$this->buffer .= Dumper::color('red', "-- FAILED: $title") . "\n$message";
+			$this->buffer[] = Dumper::color('red', "-- FAILED: $title") . "\n$message";
 		} elseif ($test->getResult() === Test::Skipped && $this->displaySkipped) {
-			$this->buffer .= "-- Skipped: $title\n$message";
+			$this->buffer[] = "-- Skipped: $title\n$message";
 		}
 	}
 
@@ -111,7 +133,7 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 	{
 		$run = array_sum($this->results);
 		fwrite($this->file, !$this->count ? "No tests found\n" :
-			"\n\n" . $this->buffer . "\n"
+			"\n\n" . implode('', $this->buffer) . "\n"
 			. ($this->results[Test::Failed] ? Dumper::color('white/red') . 'FAILURES!' : Dumper::color('white/green') . 'OK')
 			. " ($this->count test" . ($this->count > 1 ? 's' : '') . ', '
 			. ($this->results[Test::Failed] ? $this->results[Test::Failed] . ' failure' . ($this->results[Test::Failed] > 1 ? 's' : '') . ', ' : '')
@@ -119,6 +141,65 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 			. ($this->count !== $run ? ($this->count - $run) . ' not run, ' : '')
 			. sprintf('%0.1f', $this->time + microtime(true)) . ' seconds)' . Dumper::color() . "\n");
 
-		$this->buffer = '';
+		$this->buffer = [];
+		$this->resultsCount = 0;
+	}
+
+
+	private function printFinishedTestDot(Test $test): void
+	{
+		fwrite($this->file, $this->symbols[$test->getResult()]);
+	}
+
+
+	private function printFinishedTestLine(Test $test): void
+	{
+		$this->resultsCount++;
+		$result = $test->getResult();
+
+		$shortFilePath = str_replace($this->baseDir, '', $test->getFile());
+		$shortDirPath = dirname($shortFilePath) . DIRECTORY_SEPARATOR;
+		$basename = basename($shortFilePath);
+
+		// Filename.
+		if ($result === Test::Failed) {
+			$fileText =	Dumper::color('red', $shortDirPath) . Dumper::color('white/red', $basename);
+		} else {
+			$fileText =	Dumper::color('gray', $shortDirPath) . Dumper::color('silver', $basename);
+		}
+
+		// Line header.
+		$header = "· ";
+		// Test's title.
+		$titleText = $test->title
+			? Dumper::color('fuchsia', " [$test->title]")
+			: '';
+
+		// Print test's message only if it's not failed (those will be printed
+		// after all tests are finished and will contain detailed info about the
+		// failed test).
+		$message = '';
+		if ($result !== Test::Failed && $test->message) {
+			$message = $test->message;
+			$indent = str_repeat(' ', mb_strlen($header));
+
+			if (preg_match('#\n#', $message)) {
+				$message = "\n$indent" . preg_replace('#\r?\n#', '\0' . $indent, $message);
+			} else {
+				$message = Dumper::color('olive', "[$message]");
+			}
+		}
+
+		$output = sprintf(
+			"%s%s %s %s %s %s\n",
+			$header,
+			"{$this->resultsCount}/{$this->count}",
+			"$fileText{$titleText}",
+			$this->symbols[$result],
+			Dumper::color('gray', sprintf("in %.2f s", $test->getDuration())),
+			$message,
+		);
+
+		fwrite($this->file, $output);
 	}
 }

--- a/src/Runner/Test.php
+++ b/src/Runner/Test.php
@@ -28,13 +28,22 @@ class Test
 		PASSED = self::Passed,
 		SKIPPED = self::Skipped;
 
+	private const PossibleResults = [
+		self::Prepared,
+		self::Failed,
+		self::Passed,
+		self::Skipped,
+	];
+
 	public ?string $title;
 	public ?string $message = null;
 	public string $stdout = '';
 	public string $stderr = '';
 	private string $file;
-	private int $result = self::Prepared;
 	private ?float $duration = null;
+
+	/** @phpstan-var Alias_TestResultState */
+	private int $result = self::Prepared;
 
 	/** @var string[]|string[][] */
 	private $args = [];
@@ -70,6 +79,9 @@ class Test
 	}
 
 
+	/**
+	 * @phpstan-return Alias_TestResultState
+	 */
 	public function getResult(): int
 	{
 		return $this->result;
@@ -123,12 +135,17 @@ class Test
 
 
 	/**
+	 * @phpstan-param Alias_TestResultState $result
 	 * @return static
 	 */
 	public function withResult(int $result, ?string $message, ?float $duration = null): self
 	{
 		if ($this->hasResult()) {
 			throw new \LogicException("Result of test is already set to $this->result with message '$this->message'.");
+		}
+
+		if (!in_array($result, self::PossibleResults, true)) {
+			throw new \LogicException("Invalid test result $result");
 		}
 
 		$me = clone $this;

--- a/tests/RunnerOutput/OutputHandlers.expect.consoleLines.txt
+++ b/tests/RunnerOutput/OutputHandlers.expect.consoleLines.txt
@@ -1,0 +1,73 @@
+%a% | %a% | 1 thread
+
+· 1/%d% ./01-basic.fail.phptx FAIL in %f% s
+· 2/%d% ./01-basic.pass.phptx OK in %f% s
+· 3/%d% ./01-basic.skip.phptx SKIP in %f% s
+· 4/%d% ./02-title.fail.phptx [Title for output handlers] FAIL in %f% s
+· 5/%d% ./02-title.pass.phptx [Title for output handlers] OK in %f% s
+· 6/%d% ./02-title.skip.phptx [Title for output handlers] SKIP in %f% s
+· 7/%d% ./03-message.fail.phptx FAIL in %f% s
+· 8/%d% ./03-message.skip.phptx SKIP in %f% s
+  Multi
+  line
+  message.
+· 9/%d% ./04-args.fail.phptx FAIL in %f% s
+· 10/%d% ./04-args.pass.phptx OK in %f% s
+· 11/%d% ./04-args.skip.phptx SKIP in %f% s
+  Multi
+  line
+  message.
+
+
+-- FAILED: 01-basic.fail.phptx
+   Multi
+   line
+   stdout.Failed:
+
+   in %a%01-basic.fail.phptx(%d%) Tester\Assert::fail('');
+
+   STDERR:
+   Multi
+   line
+   stderr.
+
+-- FAILED: Title for output handlers | 02-title.fail.phptx
+   Multi
+   line
+   stdout.Failed:
+
+   in %a%02-title.fail.phptx(%d%) Tester\Assert::fail('');
+
+   STDERR:
+   Multi
+   line
+   stderr.
+
+-- FAILED: 03-message.fail.phptx
+   Multi
+   line
+   stdout.Failed: Multi
+   line
+   message.
+
+   in %a%03-message.fail.phptx(%d%) Tester\Assert::fail("Multi\nline\nmessage.");
+
+   STDERR:
+   Multi
+   line
+   stderr.
+
+-- FAILED: 04-args.fail.phptx dataprovider=thisIsAVeryVeryVeryLongArgumentNameToTestHowOutputHandlersDealWithItsLengthInTheirOutputFormatting|%a%provider.ini
+   Multi
+   line
+   stdout.Failed:
+
+   in %a%04-args.fail.phptx(%d%) Tester\Assert::fail('');
+
+   STDERR:
+   Multi
+   line
+   stderr.
+
+
+FAILURES! (11 tests, 4 failures, 4 skipped, %a% seconds)

--- a/tests/RunnerOutput/OutputHandlers.phpt
+++ b/tests/RunnerOutput/OutputHandlers.phpt
@@ -32,14 +32,15 @@ $runner->setEnvironmentVariable(Tester\Environment::VariableColors, '0');
 $runner->paths[] = __DIR__ . '/cases/*.phptx';
 $runner->outputHandlers[] = new Output\ConsolePrinter($runner, false, $console = FileMock::create(''));
 $runner->outputHandlers[] = new Output\ConsolePrinter($runner, true, $consoleWithSkipped = FileMock::create(''));
+$runner->outputHandlers[] = new Output\ConsolePrinter($runner, false, $consoleLines = FileMock::create(''), false, true);
 $runner->outputHandlers[] = new Output\JUnitPrinter($jUnit = FileMock::create(''));
 $runner->outputHandlers[] = new Output\Logger($runner, $logger = FileMock::create(''));
 $runner->outputHandlers[] = new Output\TapPrinter($tap = FileMock::create(''));
 $runner->run();
 
-
 Assert::matchFile(__DIR__ . '/OutputHandlers.expect.console.txt', Dumper::removeColors(file_get_contents($console)));
 Assert::matchFile(__DIR__ . '/OutputHandlers.expect.consoleWithSkip.txt', Dumper::removeColors(file_get_contents($consoleWithSkipped)));
+Assert::matchFile(__DIR__ . '/OutputHandlers.expect.consoleLines.txt', Dumper::removeColors(file_get_contents($consoleLines)));
 Assert::matchFile(__DIR__ . '/OutputHandlers.expect.jUnit.xml', file_get_contents($jUnit));
 Assert::matchFile(__DIR__ . '/OutputHandlers.expect.logger.txt', file_get_contents($logger));
 Assert::matchFile(__DIR__ . '/OutputHandlers.expect.tap.txt', file_get_contents($tap));


### PR DESCRIPTION
Usage example:
```sh
$ ./src/tester -C -o console-lines tests/
```

This is handy for environments with "non-standard" _(buffered, I guess?)_ handling of standard output, for example `Github Actions` _(where a progress of tests cannot be seen until until end-of-line appears, which in standard `console` mode happens only when all tests finish)_ or `Docker Compose` logging output _(where in standard `console` mode each finished test's dot is printed alone on separate line)_.

Or the `console-lines` mode can be handy just to see a more detailed progress of tests in all environments, because it outputs something like this:

<table>
<tr>
<td>Passing tests</td>
<td>Failing tests</td>
<td>Usage</td>
<td>Also supports "cider mode"</td>
<tr/>
<tr>
<td>

![obrazek](https://github.com/nette/tester/assets/6860713/e55c6e11-0aec-404a-80c1-f5a58e9e5bc9)

</td>
<td>

![obrazek](https://github.com/nette/tester/assets/6860713/da150d3c-e327-47ea-80d3-4634c205f3d3)

</td>
<td>

![obrazek](https://github.com/nette/tester/assets/6860713/abc9a383-276c-4d88-a0b9-c4f8bfd8e810)

</td>
<td>

![obrazek](https://github.com/nette/tester/assets/6860713/bdb3938e-794b-4df5-9400-a17887281127)

</td>
<tr/>
</table>

Also, "cider mode" now shows a lemon emoji for skipped tests.

- ***new feature***
- BC break? ***no***
- doc PR: https://github.com/nette/docs/pull/1027

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
