### PR TITLE
Remove NULL byte from class names, which cause problems when using phpdbg

### DIFF
--- a/src/Framework/TestCase.php
+++ b/src/Framework/TestCase.php
@@ -213,8 +213,13 @@ class TestCase
 	{
 		Environment::$checkAssertions = false;
 		header('Content-Type: text/plain');
+
+		// Class name might contain NULL byte (e.g. for anonymous classes),
+		// which might mess up our output.
+		$cleanClassName = str_replace("\0", '', static::class);
+
 		echo "\n";
-		echo 'TestCase:' . static::class . "\n";
+		echo 'TestCase:' . $cleanClassName . "\n";
 		echo 'Method:' . implode("\nMethod:", $methods) . "\n";
 
 		$dependentFiles = [];


### PR DESCRIPTION
Resolves https://github.com/nette/tester/issues/449

- bug fix
- BC break? no (hopefully)

---

New output, which is now correct (from what is described in the issue):

```
[smuuf@smuuf-hp]$ phpdbg8.2 -qrrb -d memory_limit=4096M -d register_argc_argv=on anonclasstestcase.phpt --method=nette-tester-list-methods

TestCase:Tester\TestCase@anonymous/mnt/d/produkce/coding/php/php-nette-tester/anonclasstestcase.phpt:8$0
Method:testMe
Dependency:/mnt/d/produkce/coding/php/php-nette-tester/anonclasstestcase.phpt
Dependency:/mnt/d/produkce/coding/php/php-nette-tester/src/Framework/TestCase.php
```

```
[smuuf@smuuf-hp]$ php8.2 -d memory_limit=4096M -d register_argc_argv=on anonclasstestcase.phpt --method=nette-tester-list-methods

TestCase:Tester\TestCase@anonymous/mnt/d/produkce/coding/php/php-nette-tester/anonclasstestcase.phpt:8$0
Method:testMe
Dependency:/mnt/d/produkce/coding/php/php-nette-tester/anonclasstestcase.phpt
Dependency:/mnt/d/produkce/coding/php/php-nette-tester/src/Framework/TestCase.php
```