### PR TITLE
Add testcase method's name to the test's title

### DIFF
--- a/src/Framework/Helpers.php
+++ b/src/Framework/Helpers.php
@@ -71,7 +71,7 @@ class Helpers
 
 
 	/**
-	 * Parse phpDoc comment.
+	 * Parse the first docblock encountered in the provided string.
 	 * @internal
 	 */
 	public static function parseDocComment(string $s): array
@@ -81,10 +81,14 @@ class Helpers
 			return [];
 		}
 
+		// The first non-@tagged string encountered in a multiline docblock will
+		// be stored at index 0.
 		if (preg_match('#^[ \t\*]*+([^\s@].*)#mi', $content[1], $matches)) {
 			$options[0] = trim($matches[1]);
 		}
 
+		// Parse @tags and their arguments. If there are multiple identically
+		// named tags, their arguments will be returned as a list of string.
 		preg_match_all('#^[ \t\*]*@(\w+)([^\w\r\n].*)?#mi', $content[1], $matches, PREG_SET_ORDER);
 		foreach ($matches as $match) {
 			$ref = &$options[strtolower($match[1])];

--- a/src/Runner/Test.php
+++ b/src/Runner/Test.php
@@ -43,7 +43,7 @@ class Test
 	public function __construct(string $file, ?string $title = null)
 	{
 		$this->file = $file;
-		$this->title = $title;
+		$this->title = $title !== null ? trim($title) : null;
 	}
 
 
@@ -97,6 +97,29 @@ class Test
 	public function getOutput(): string
 	{
 		return $this->stdout . ($this->stderr ? "\nSTDERR:\n" . $this->stderr : '');
+	}
+
+
+	public function withAppendedTitle(string $title): self
+	{
+		if ($this->hasResult()) {
+			throw new \LogicException('Cannot append title to test which already has a result.');
+		}
+
+		$title = trim($title);
+		$me = clone $this;
+
+		if ($title === '') {
+			return $me;
+		}
+
+		// At this point we're sure both $me->title and $title do not have
+		// leading/trailing whitespace.
+		$me->title = $me->title !== null
+			? "{$me->title} {$title}"
+			: $title;
+
+		return $me;
 	}
 
 

--- a/src/Runner/TestHandler.php
+++ b/src/Runner/TestHandler.php
@@ -228,7 +228,10 @@ class TestHandler
 		}
 
 		return array_map(
-			fn(string $method): Test => $test->withArguments(['method' => $method]),
+			fn(string $method): Test => $test
+				// Add the testcase method's name to the test's title.
+				->withAppendedTitle($method)
+				->withArguments(['method' => $method]),
 			$methods,
 		);
 	}

--- a/tests/Runner/Job.phpt
+++ b/tests/Runner/Job.phpt
@@ -28,3 +28,29 @@ test('', function () {
 		Assert::contains('Nette Tester', $job->getHeaders());
 	}
 });
+
+
+test('Appending title to a Test object w/o initial title', function () {
+	$testA = (new Test('Job.test.phptx'));
+	Assert::null($testA->title);
+
+	$testB = $testA->withAppendedTitle('title B');
+	Assert::notSame($testB, $testA);
+	Assert::same('title B', $testB->title);
+
+	$testC = $testB->withAppendedTitle(" \t    title C  ");
+	Assert::notSame($testC, $testB);
+	Assert::same('title B title C', $testC->title);
+});
+
+
+test('Appending title to a Test object w/ initial title', function () {
+	$testA = (new Test('Job.test.phptx', 'Initial title   '));
+	Assert::same('Initial title', $testA->title);
+
+	$testB = $testA->withAppendedTitle('   ');
+	Assert::same('Initial title', $testB->title);
+
+	$testC = $testB->withAppendedTitle(" \t    MEGATITLE  ");
+	Assert::same('Initial title MEGATITLE', $testC->title);
+});


### PR DESCRIPTION
Resolves https://github.com/nette/tester/issues/448.

- new feature
- BC break? no (hopefully)

## What this does

For tests wrapped in testcase class:
```php
class MyTests extends \Tester\Testcase {
    public function testMethod_1() { ... }
    public function testMethod_2() { ... }
}
```

... where Tester creates a separate `Test` object for each of the testcase's methods, ***we now add (append) the method's name to the (maybe already specified) test's title***.

In the case of these two methods, if this PR is merged, the first test object will now have the title `"testMethod_1"` and the second one will have the title `"testMethod_2"`.

## What is looks like
... if Nette Tester self-tests with [`-o console-lines` output mode](https://github.com/nette/tester/pull/443):
![obrazek](https://github.com/nette/tester/assets/6860713/7fc9ed2b-9725-4b71-9631-b4973edfdc75)

## Append... title?
Yes, the test file might also contain "a primary, standalone title definition", like so:

```php
/**
 * These are my tests
 */
class MyTests extends \Tester\Testcase {
    public function testMethod_1() { ... }
    public function testMethod_2() { ... }
}
```

... in that case the test objects representing both methods would have a same, pre-specified title `"These are my tests"`.

This PR changes this and in the end the first test object would have the title `"These are my tests testMethod_1"` and the second one will have the title `"These are my tests testMethod_2"`.