### PR TITLE
Fix: first 5 characters is too weak for collisions

### DIFF
--- a/src/Runner/TestHandler.php
+++ b/src/Runner/TestHandler.php
@@ -176,7 +176,7 @@ class TestHandler
 		$methods = null;
 
 		if ($this->tempDir) {
-			$cacheFile = $this->tempDir . DIRECTORY_SEPARATOR . 'TestHandler.testCase.' . substr(md5($test->getSignature()), 0, 5) . '.list';
+			$cacheFile = $this->tempDir . DIRECTORY_SEPARATOR . 'TestHandler.testCase.' . md5($test->getSignature()) . '.list';
 			if (is_file($cacheFile)) {
 				$cache = unserialize(file_get_contents($cacheFile));
 


### PR DESCRIPTION
Use full length of MD5 to make collisions more difficult

- bug fix / new feature?   Bugfix
- BC break? no
- doc PR: just fixed issue

This PR fixed rare situation, when first 5 characters in MD5 of file was same, so Nette/Tester could not run tests properly.
