### PR TITLE
Declare PHP 8.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macOS-latest]
-                php: ['8.0', '8.1', '8.2', '8.3', '8.4']
+                php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
             fail-fast: false
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		}
 	],
 	"require": {
-		"php": "8.0 - 8.4"
+		"php": "8.0 - 8.5"
 	},
 	"require-dev": {
 		"ext-simplexml": "*",

--- a/src/CodeCoverage/Generators/AbstractGenerator.php
+++ b/src/CodeCoverage/Generators/AbstractGenerator.php
@@ -70,7 +70,7 @@ abstract class AbstractGenerator
 			throw new \Exception("Unable to write to file '$file'.");
 		}
 
-		ob_start(function (string $buffer) use ($handle) { fwrite($handle, $buffer); }, 4096);
+		ob_start(function (string $buffer) use ($handle) { fwrite($handle, $buffer); return ''; }, 4096);
 		try {
 			$this->renderSelf();
 		} catch (\Throwable $e) {


### PR DESCRIPTION
paving the way to support PHP 8.5 so other dev-tooling which depend on nette/* packages can start supporting 8.5 as well