### PR TITLE
Fix PHP 8.5 deprecation: null as array offset in -o option handler

### DIFF
--- a/src/Runner/CliTester.php
+++ b/src/Runner/CliTester.php
@@ -136,15 +136,15 @@ class CliTester
 				'--cider' => [],
 				'--coverage-src' => [CommandLine::RealPath => true, CommandLine::Repeatable => true],
 				'-o' => [CommandLine::Repeatable => true, CommandLine::Normalizer => function ($arg) use (&$outputFiles) {
-					[$format, $file] = explode(':', $arg, 2) + [1 => null];
+					[$format, $file] = explode(':', $arg, 2) + [1 => ''];
 
 					if (isset($outputFiles[$file])) {
 						throw new \Exception(
-							$file === null
+							$file === ''
 								? 'Option -o <format> without file name parameter can be used only once.'
 								: "Cannot specify output by -o into file '$file' more then once.",
 						);
-					} elseif ($file === null) {
+					} elseif ($file === '') {
 						$this->stdoutFormat = $format;
 					}
 


### PR DESCRIPTION
## Summary
- Fix PHP 8.5 deprecation warning when using `-o console` without a filename
- PHP 8.5 deprecated using `null` as an array offset; when no filename is specified, `$file` was `null` and used as key in `$outputFiles[$file]`
- Changed default from `null` to empty string `''` and updated corresponding checks

## Test plan
- [x] Verified all 88 tests pass with `src/tester tests -s -C`
- [x] Confirmed output handlers work correctly (they use `$file ?: 'php://output'` which handles empty string the same as null)