### PR TITLE
Add Countable to the count() doctype

### DIFF
--- a/src/Framework/Assert.php
+++ b/src/Framework/Assert.php
@@ -265,7 +265,7 @@ class Assert
 
 	/**
 	 * Asserts the number of items in an array or Countable.
-	 * @param mixed[]  $value
+	 * @param mixed[]|\Countable  $value
 	 */
 	public static function count(int $count, array|\Countable $value, ?string $description = null): void
 	{


### PR DESCRIPTION
- bug fix / new feature?   bug fix, more or less
- BC break? no

Add `Countable` to the doctype, the native param type contains it as well.