### PR TITLE
PhpInterpreter: pass command to proc_open() as array

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,6 +61,18 @@ parameters:
 			path: src/Runner/CommandLine.php
 
 		-
+			message: '#^Call to function method_exists\(\) with Tester\\Runner\\OutputHandler and ''jobStarted'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Tester\\Runner\\OutputHandler and ''tick'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
 			message: '#^If condition is always false\.$#'
 			identifier: if.alwaysFalse
 			count: 1

--- a/src/Framework/Ansi.php
+++ b/src/Framework/Ansi.php
@@ -83,6 +83,23 @@ class Ansi
 
 
 	/**
+	 * Returns ANSI sequence to move the cursor by the given number of columns (x) and rows (y).
+	 */
+	public static function cursorMove(int $x = 0, int $y = 0): string
+	{
+		return match (true) {
+			$x < 0 => "\e[" . (-$x) . 'D',
+			$x > 0 => "\e[{$x}C",
+			default => '',
+		} . match (true) {
+			$y < 0 => "\e[" . (-$y) . 'A',
+			$y > 0 => "\e[{$y}B",
+			default => '',
+		};
+	}
+
+
+	/**
 	 * Returns ANSI sequence to clear from cursor to end of line.
 	 */
 	public static function clearLine(): string
@@ -114,7 +131,57 @@ class Ansi
 	 */
 	public static function textWidth(string $text): int
 	{
+		$text = self::stripAnsi($text);
 		return preg_match_all('/./su', $text)
 			+ preg_match_all('/[\x{1F300}-\x{1F9FF}]/u', $text); // emoji are 2-wide
+	}
+
+
+	/**
+	 * Pads text to specified display width.
+	 * @param STR_PAD_LEFT|STR_PAD_RIGHT|STR_PAD_BOTH  $type
+	 */
+	public static function pad(
+		string $text,
+		int $width,
+		string $char = ' ',
+		int $type = STR_PAD_RIGHT,
+	): string
+	{
+		$padding = $width - self::textWidth($text);
+		if ($padding <= 0) {
+			return $text;
+		}
+
+		return match ($type) {
+			STR_PAD_LEFT => str_repeat($char, $padding) . $text,
+			STR_PAD_RIGHT => $text . str_repeat($char, $padding),
+			STR_PAD_BOTH => str_repeat($char, intdiv($padding, 2)) . $text . str_repeat($char, $padding - intdiv($padding, 2)),
+		};
+	}
+
+
+	/**
+	 * Truncates text to max display width, adding ellipsis if needed.
+	 */
+	public static function truncate(string $text, int $maxWidth, string $ellipsis = '…'): string
+	{
+		if (self::textWidth($text) <= $maxWidth) {
+			return $text;
+		}
+
+		$maxWidth -= self::textWidth($ellipsis);
+		$res = '';
+		$width = 0;
+		foreach (preg_split('//u', $text, -1, PREG_SPLIT_NO_EMPTY) as $char) {
+			$charWidth = preg_match('/[\x{1F300}-\x{1F9FF}]/u', $char) ? 2 : 1;
+			if ($width + $charWidth > $maxWidth) {
+				break;
+			}
+			$res .= $char;
+			$width += $charWidth;
+		}
+
+		return $res . $ellipsis;
 	}
 }

--- a/src/Runner/CliTester.php
+++ b/src/Runner/CliTester.php
@@ -267,7 +267,7 @@ class CliTester
 	{
 		$engines = $this->interpreter->getCodeCoverageEngines();
 		if (count($engines) < 1) {
-			throw new \Exception("Code coverage functionality requires Xdebug or PCOV extension or PHPDBG SAPI (used {$this->interpreter->getCommandLine()})");
+			throw new \Exception("Code coverage functionality requires Xdebug or PCOV extension or PHPDBG SAPI (used {$this->interpreter->getCommandLineStr()})");
 		}
 
 		file_put_contents($this->options['--coverage'], '');

--- a/src/Runner/Job.php
+++ b/src/Runner/Job.php
@@ -95,7 +95,7 @@ class Job
 		$this->duration = -microtime(as_float: true);
 		$this->proc = proc_open(
 			$this->interpreter
-				->withArguments(['-d register_argc_argv=on', $this->test->getFile(), ...$args])
+				->withArguments(['-d', 'register_argc_argv=on', $this->test->getFile(), ...$args])
 				->getCommandLine(),
 			[
 				['pipe', 'r'],

--- a/src/Runner/Output/ConsolePrinter.php
+++ b/src/Runner/Output/ConsolePrinter.php
@@ -67,7 +67,7 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 			$this->mode = self::ModeLines;
 		}
 		fwrite($this->file, $this->runner->getInterpreter()->getShortInfo()
-			. ' | ' . $this->runner->getInterpreter()->getCommandLine()
+			. ' | ' . $this->runner->getInterpreter()->getCommandLineStr()
 			. " | {$this->runner->threadCount} thread" . ($this->runner->threadCount > 1 ? 's' : '') . "\n\n");
 	}
 

--- a/src/Runner/Output/ConsolePrinter.php
+++ b/src/Runner/Output/ConsolePrinter.php
@@ -9,9 +9,11 @@ namespace Tester\Runner\Output;
 
 use Tester;
 use Tester\Ansi;
+use Tester\Environment;
+use Tester\Runner\Job;
 use Tester\Runner\Runner;
 use Tester\Runner\Test;
-use function sprintf, strlen;
+use function count, fwrite, sprintf, str_repeat, strlen;
 use const DIRECTORY_SEPARATOR;
 
 
@@ -24,6 +26,8 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 	public const ModeCider = 2;
 	public const ModeLines = 3;
 
+	private const MaxDisplayedThreads = 20;
+
 	/** @var resource */
 	private $file;
 	private string $buffer;
@@ -33,6 +37,11 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 	/** @var array<Test::Passed|Test::Skipped|Test::Failed, int>  result type => count */
 	private array $results;
 	private ?string $baseDir;
+	private int $panelWidth = 60;
+	private int $panelHeight = 0;
+
+	/** @var \WeakMap<Job, float> */
+	private \WeakMap $startTimes;
 
 
 	public function __construct(
@@ -43,6 +52,7 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 		private int $mode = self::ModeDots,
 	) {
 		$this->file = fopen($file ?? 'php://output', 'w') ?: throw new \RuntimeException("Cannot open file '$file' for writing.");
+		$this->startTimes = new \WeakMap;
 	}
 
 
@@ -53,6 +63,9 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 		$this->baseDir = null;
 		$this->results = [Test::Passed => 0, Test::Skipped => 0, Test::Failed => 0];
 		$this->time = -microtime(as_float: true);
+		if ($this->mode === self::ModeCider && $this->runner->threadCount < 2) {
+			$this->mode = self::ModeLines;
+		}
 		fwrite($this->file, $this->runner->getInterpreter()->getShortInfo()
 			. ' | ' . $this->runner->getInterpreter()->getCommandLine()
 			. " | {$this->runner->threadCount} thread" . ($this->runner->threadCount > 1 ? 's' : '') . "\n\n");
@@ -89,7 +102,7 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 		$this->results[$result]++;
 		fwrite($this->file, match ($this->mode) {
 			self::ModeDots => [Test::Passed => '.', Test::Skipped => 's', Test::Failed => Ansi::colorize('F', 'white/red')][$result],
-			self::ModeCider => [Test::Passed => '🍏', Test::Skipped => 's', Test::Failed => '🍎'][$result],
+			self::ModeCider => '',
 			self::ModeLines => $this->generateFinishLine($test),
 		});
 
@@ -106,6 +119,12 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 
 	public function end(): void
 	{
+		if ($this->panelHeight) {
+			fwrite($this->file, Ansi::cursorMove(y: -$this->panelHeight)
+				. str_repeat(Ansi::clearLine() . "\n", $this->panelHeight)
+				. Ansi::cursorMove(y: -$this->panelHeight));
+		}
+
 		$run = array_sum($this->results);
 		fwrite($this->file, !$this->count ? "No tests found\n" :
 			"\n\n" . $this->buffer . "\n"
@@ -157,5 +176,77 @@ class ConsolePrinter implements Tester\Runner\OutputHandler
 			Ansi::colorize(sprintf('in %.2f s', $test->getDuration()), 'gray'),
 			$message,
 		);
+	}
+
+
+	public function jobStarted(Job $job): void
+	{
+		$this->startTimes[$job] = microtime(true);
+	}
+
+
+	/**
+	 * @param Job[]  $running
+	 */
+	public function tick(array $running): void
+	{
+		if ($this->mode !== self::ModeCider) {
+			return;
+		}
+
+		// Move cursor up to overwrite previous output
+		if ($this->panelHeight) {
+			fwrite($this->file, Ansi::cursorMove(y: -$this->panelHeight));
+		}
+
+		$lines = [];
+
+		// Header with progress bar
+		$barWidth = $this->panelWidth - 12;
+		$filled = (int) round($barWidth * ($this->runner->getFinishedCount() / $this->runner->getJobCount()));
+		$lines[] = '╭' . Ansi::pad(' ' . str_repeat('█', $filled) . str_repeat('░', $barWidth - $filled) . ' ', $this->panelWidth - 2, '─', STR_PAD_BOTH) . '╮';
+
+		$threadJobs = [];
+		foreach ($running as $job) {
+			$threadJobs[(int) $job->getEnvironmentVariable(Environment::VariableThread)] = $job;
+		}
+
+		// Thread lines
+		$numWidth = strlen((string) $this->runner->threadCount);
+		$displayCount = min($this->runner->threadCount, self::MaxDisplayedThreads);
+
+		for ($t = 1; $t <= $displayCount; $t++) {
+			if (isset($threadJobs[$t])) {
+				$job = $threadJobs[$t];
+				$name = basename($job->getTest()->getFile());
+				$time = sprintf('%0.1fs', microtime(true) - ($this->startTimes[$job] ?? microtime(true)));
+				$nameWidth = $this->panelWidth - $numWidth - strlen($time) - 7;
+				$name = Ansi::pad(Ansi::truncate($name, $nameWidth), $nameWidth);
+				$line = Ansi::colorize(sprintf("%{$numWidth}d:", $t), 'lime') . " $name " . Ansi::colorize($time, 'yellow');
+			} else {
+				$line = Ansi::pad(Ansi::colorize(sprintf("%{$numWidth}d: -", $t), 'gray'), $this->panelWidth - 4);
+			}
+			$lines[] = '│ ' . $line . ' │';
+		}
+
+		if ($this->runner->threadCount > self::MaxDisplayedThreads) {
+			$more = $this->runner->threadCount - self::MaxDisplayedThreads;
+			$ellipsis = Ansi::colorize("… and $more more", 'gray');
+			$lines[] = '│' . Ansi::pad($ellipsis, $this->panelWidth - 2) . '│';
+		}
+
+		// Footer: (85 tests, 🍏×74 🍎×2, 9.0s)
+		$summary = "($this->count tests, "
+			. ($this->results[Test::Passed] ? "🍏×{$this->results[Test::Passed]}" : '')
+			. ($this->results[Test::Failed] ? " 🍎×{$this->results[Test::Failed]}" : '')
+			. ', ' . sprintf('%0.1fs', $this->time + microtime(true)) . ')';
+		$lines[] = '╰' . Ansi::pad($summary, $this->panelWidth - 2, '─', STR_PAD_BOTH) . '╯';
+
+		foreach ($lines as $line) {
+			fwrite($this->file, "\r" . $line . Ansi::clearLine() . "\n");
+		}
+		fflush($this->file);
+
+		$this->panelHeight = count($lines);
 	}
 }

--- a/src/Runner/Output/Logger.php
+++ b/src/Runner/Output/Logger.php
@@ -38,7 +38,7 @@ class Logger implements Tester\Runner\OutputHandler
 		$this->count = 0;
 		$this->results = [Test::Passed => 0, Test::Skipped => 0, Test::Failed => 0];
 		fwrite($this->file, 'PHP ' . $this->runner->getInterpreter()->getVersion()
-			. ' | ' . $this->runner->getInterpreter()->getCommandLine()
+			. ' | ' . $this->runner->getInterpreter()->getCommandLineStr()
 			. " | {$this->runner->threadCount} threads\n\n");
 	}
 

--- a/src/Runner/OutputHandler.php
+++ b/src/Runner/OutputHandler.php
@@ -10,6 +10,8 @@ namespace Tester\Runner;
 
 /**
  * Receives test lifecycle events from the runner to produce output.
+ * @method void jobStarted(Job $job) called when a job starts running
+ * @method void tick(Job[] $running) called periodically during test execution
  */
 interface OutputHandler
 {

--- a/src/Runner/PhpInterpreter.php
+++ b/src/Runner/PhpInterpreter.php
@@ -16,7 +16,7 @@ use function count, in_array;
  */
 class PhpInterpreter
 {
-	private string $commandLine;
+	private array $commandLine;
 	private bool $cgi;
 	private \stdClass $info;
 	private string $error;
@@ -25,14 +25,10 @@ class PhpInterpreter
 	/** @param string[]  $args */
 	public function __construct(string $path, array $args = [])
 	{
-		$this->commandLine = Helpers::escapeArg($path);
 		$proc = @proc_open( // @ is escalated to exception
-			$this->commandLine . ' --version',
+			[$path, '--version'],
 			[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
 			$pipes,
-			null,
-			null,
-			['bypass_shell' => true],
 		);
 		if ($proc === false) {
 			throw new \Exception("Cannot run PHP interpreter $path. Use -p option.");
@@ -42,20 +38,22 @@ class PhpInterpreter
 		$output = stream_get_contents($pipes[1]);
 		proc_close($proc);
 
-		$args = ' ' . implode(' ', array_map([Helpers::class, 'escapeArg'], $args));
+		$this->commandLine = array_merge([$path], $args);
 		if (str_contains($output, 'phpdbg')) {
-			$args = ' -qrrb -S cli' . $args;
+			array_push($this->commandLine, '-qrrb', '-S', 'cli');
 		}
 
-		$this->commandLine .= rtrim($args);
-
 		$proc = proc_open(
-			$this->commandLine . ' -d register_argc_argv=on ' . Helpers::escapeArg(__DIR__ . '/info.php') . ' serialized',
+			array_merge(
+				$this->commandLine,
+				[
+					'-d', 'register_argc_argv=on',
+					__DIR__ . '/info.php',
+					'serialized',
+				],
+			),
 			[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
 			$pipes,
-			null,
-			null,
-			['bypass_shell' => true],
 		) ?: throw new \Exception("Unable to run $path.");
 
 		$output = stream_get_contents($pipes[1]);
@@ -88,7 +86,7 @@ class PhpInterpreter
 	public function withArguments(array $args): static
 	{
 		$me = clone $this;
-		$me->commandLine .= ' ' . implode(' ', array_map([Helpers::class, 'escapeArg'], $args));
+		array_push($me->commandLine, ...$args);
 		return $me;
 	}
 
@@ -98,13 +96,19 @@ class PhpInterpreter
 	 */
 	public function withPhpIniOption(string $name, ?string $value = null): static
 	{
-		return $this->withArguments(['-d ' . $name . ($value === null ? '' : "=$value")]);
+		return $this->withArguments(['-d', $name . ($value === null ? '' : "=$value")]);
 	}
 
 
-	public function getCommandLine(): string
+	public function getCommandLine(): array
 	{
 		return $this->commandLine;
+	}
+
+
+	public function getCommandLineStr(): string
+	{
+		return implode(' ', array_map([Helpers::class, 'escapeArg'], $this->commandLine));
 	}
 
 

--- a/tests/Framework/Ansi.pad.phpt
+++ b/tests/Framework/Ansi.pad.phpt
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+use Tester\Ansi;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// pad() - right (default)
+Assert::same('hello     ', Ansi::pad('hello', 10));
+Assert::same('hello     ', Ansi::pad('hello', 10, ' ', STR_PAD_RIGHT));
+
+// pad() - left
+Assert::same('     hello', Ansi::pad('hello', 10, ' ', STR_PAD_LEFT));
+
+// pad() - center (both)
+Assert::same('  hello   ', Ansi::pad('hello', 10, ' ', STR_PAD_BOTH));
+Assert::same('   hi   ', Ansi::pad('hi', 8, ' ', STR_PAD_BOTH)); // odd padding: 3 left, 3 right
+Assert::same('  hi   ', Ansi::pad('hi', 7, ' ', STR_PAD_BOTH)); // odd padding: 2 left, 3 right
+
+// pad() - text already at width
+Assert::same('hello', Ansi::pad('hello', 5));
+Assert::same('hello', Ansi::pad('hello', 3)); // over width, no change
+
+// pad() - unicode padding character
+Assert::same('hello─────', Ansi::pad('hello', 10, '─'));
+Assert::same('─────hello', Ansi::pad('hello', 10, '─', STR_PAD_LEFT));
+Assert::same('──hello───', Ansi::pad('hello', 10, '─', STR_PAD_BOTH));
+
+// pad() - text with emoji (emoji is 2-wide)
+Assert::same('🍏×5    ', Ansi::pad('🍏×5', 8)); // 🍏(2) + ×(1) + 5(1) = 4 width, need 4 spaces
+Assert::same('    🍏×5', Ansi::pad('🍏×5', 8, ' ', STR_PAD_LEFT));
+
+// pad() - empty string
+Assert::same('     ', Ansi::pad('', 5));

--- a/tests/Framework/Ansi.truncate.phpt
+++ b/tests/Framework/Ansi.truncate.phpt
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+use Tester\Ansi;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// truncate() - no truncation needed
+Assert::same('hello', Ansi::truncate('hello', 10));
+Assert::same('hello', Ansi::truncate('hello', 5)); // exactly at width
+
+// truncate() - basic truncation
+Assert::same('hel…', Ansi::truncate('hello', 4));
+Assert::same('h…', Ansi::truncate('hello', 2));
+Assert::same('hello wor…', Ansi::truncate('hello world', 10));
+
+// truncate() - custom ellipsis
+Assert::same('hello...', Ansi::truncate('hello world', 8, '...'));
+Assert::same('hell...', Ansi::truncate('hello world', 7, '...'));
+
+// truncate() - unicode text
+Assert::same('příl…', Ansi::truncate('příliš', 5));
+Assert::same('žlu…', Ansi::truncate('žluťoučký', 4));
+
+// truncate() - text with emoji (emoji is 2-wide)
+Assert::same('🍏…', Ansi::truncate('🍏🍎🍏', 4)); // 🍏(2) + …(1) = 3, fits in 4
+Assert::same('🍏🍎…', Ansi::truncate('🍏🍎🍏', 5)); // 🍏(2) + 🍎(2) + …(1) = 5, fits in 5
+Assert::same('a🍏…', Ansi::truncate('a🍏🍎', 4)); // a(1) + 🍏(2) + …(1) = 4, fits in 4
+
+// truncate() - edge case: maxWidth smaller than ellipsis
+Assert::same('…', Ansi::truncate('hello', 1));
+
+// truncate() - empty string
+Assert::same('', Ansi::truncate('', 5));

--- a/tests/Runner/PhpInterpreter.phpt
+++ b/tests/Runner/PhpInterpreter.phpt
@@ -35,6 +35,6 @@ Assert::count($count, $engines);
 
 // createInterpreter() uses same php.ini as parent
 if (!$interpreter->isCgi()) {
-	$output = shell_exec($interpreter->withArguments(['-r echo php_ini_loaded_file();'])->getCommandLine());
+	$output = shell_exec($interpreter->withArguments(['-r', 'echo php_ini_loaded_file();'])->getCommandLineStr());
 	Assert::same(php_ini_loaded_file(), $output);
 }


### PR DESCRIPTION
I noticed in PHP manual that `$command` to `proc_open()` can be passed as an array. In that case:
- PHP escapes arguments itself (seems more secure)
- subshell call is bypassed on Linux too (micro speed-up)
